### PR TITLE
Add setup for tabs

### DIFF
--- a/src/Tab.tsx
+++ b/src/Tab.tsx
@@ -1,0 +1,51 @@
+import clsx from "clsx";
+import { useState } from "react";
+
+export const Tabs = ({ children }: any) => {
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
+
+  if (!Array.isArray(children)) {
+    children = [children];
+  }
+
+  const tabs = children.filter((child: any) => {
+    // TODO: remove isTab for storybook
+    return child.props.mdxType === "Tab" || child.props.isTab;
+  });
+
+  if (tabs.length === 0) {
+    return null;
+  }
+
+  const activeTabContent = tabs[activeTabIndex].props.children;
+
+  return (
+    <>
+      <div className="not-prose mb-6">
+        <div className="flex-none min-w-full overflow-auto">
+          <ul className="border-b border-slate-200 space-x-6 flex whitespace-nowrap dark:border-slate-200/5">
+            {tabs.map((tab: any, i: number) => (
+              <li onClick={() => setActiveTabIndex(i)}>
+                <h2
+                  className={clsx(
+                    "flex text-sm leading-6 font-semibold pt-3 pb-2.5 border-b-2 -mb-px cursor-pointer",
+                    i === activeTabIndex
+                      ? "text-primary dark:text-primary-light border-current"
+                      : "text-slate-900 border-transparent hover:border-slate-300 dark:text-slate-200 dark:hover:border-slate-700"
+                  )}
+                >
+                  {tab.props.title}
+                </h2>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+      <div className="prose dark:prose-dark">{activeTabContent}</div>
+    </>
+  );
+};
+
+export const Tab = ({ children }: any) => {
+  return children;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { Info, Warning, Note, Tip, Check } from "./Callouts";
 import { Frame } from "./Frame";
 import { Param } from "./Param";
 import { UserDefinedIcon } from "./UserDefinedIcon";
+import { Tabs, Tab } from "./Tab";
 
 // Import Tailwind
 import "./css/globals.css";
@@ -24,4 +25,6 @@ export {
   Frame,
   Param,
   UserDefinedIcon,
+  Tabs,
+  Tab,
 };

--- a/src/stories/Tab.stories.tsx
+++ b/src/stories/Tab.stories.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { Tabs, Tab } from "../Tab";
+
+export default {
+  title: "Display/Tabs",
+  component: Tabs,
+} as ComponentMeta<typeof Tabs>;
+
+const Template: ComponentStory<typeof Tabs> = (args) => (
+  <Tabs>
+    <Tab title="Lorem Titalis 1" isTab>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua.
+    </Tab>
+    <Tab title="Ipsum Titalis 2" isTab>
+      Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+      aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+      voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+    </Tab>
+  </Tabs>
+);
+
+export const ThreeTabs = Template.bind({});


### PR DESCRIPTION
# Summary

This PR adds the new `<Tabs>` and `<Tab>` components
<img width="1198" alt="Screen Shot 2022-09-16 at 10 59 56 AM" src="https://user-images.githubusercontent.com/44352119/190703022-25f1385e-74bb-45c4-a912-1cf7fa2cc919.png">
