### PR TITLE
Move API Playground to components but do not expose the values yet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mintlify/components",
-  "version": "0.1.45",
+  "version": "0.1.52",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mintlify/components",
-      "version": "0.1.45",
+      "version": "0.1.52",
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.7.3",

--- a/src/Api/ApiInput.tsx
+++ b/src/Api/ApiInput.tsx
@@ -1,0 +1,349 @@
+import clsx from "clsx";
+import { useState } from "react";
+import { ApiInputValue, Param } from "./types";
+
+const getArrayType = (type: string | undefined) => {
+  if (!type || type === "array") {
+    return "";
+  }
+  return type.replace(/\[\]/g, "");
+};
+
+function AddArrayItemButton({ onClick }: { onClick: () => void }) {
+  return (
+    <div className="relative">
+      <button
+        className="w-full py-0.5 px-2 rounded text-left border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 hover:border-slate-400 dark:hover:border-slate-500"
+        onClick={onClick}
+      >
+        Add Item
+      </button>
+      <svg
+        className="hidden sm:block absolute right-2 top-[7px] h-3 fill-slate-500 dark:fill-slate-400"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 448 512"
+      >
+        <path d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32V224H48c-17.7 0-32 14.3-32 32s14.3 32 32 32H192V432c0 17.7 14.3 32 32 32s32-14.3 32-32V288H400c17.7 0 32-14.3 32-32s-14.3-32-32-32H256V80z" />
+      </svg>
+    </div>
+  );
+}
+
+export function ApiInput({
+  param,
+  value,
+  onChangeParam,
+  onObjectPropertyChange,
+  onArrayItemChange,
+  onDeleteArrayItem,
+  parentInputs = [],
+}: {
+  param: Param;
+  value: ApiInputValue;
+  onChangeParam: (
+    parentInputs: string[],
+    paramName: string,
+    value: ApiInputValue
+  ) => void;
+  onObjectPropertyChange?: (value: any) => void;
+  onArrayItemChange?: (value: any) => void;
+  onDeleteArrayItem?: () => void;
+  parentInputs?: string[];
+}) {
+  const [isExpandedProperties, setIsExpandedProperties] = useState(
+    Boolean(param.required) || param.type === "array"
+  );
+  const [object, setObject] = useState<Record<string, any>>(
+    param.type === "object" ? (value as any) : {}
+  );
+  const [array, setArray] = useState<{ param: Param; value: any }[]>(
+    param.type === "array" ? (value as any[]) : []
+  );
+
+  let InputField;
+
+  // Todo: support multiple types
+  let lowerCaseParamType;
+  if (typeof param.type === "string") {
+    lowerCaseParamType = param.type?.toLowerCase();
+  }
+
+  const isObject = param.properties != null;
+  const isArray = param.type === "array";
+
+  const onInputChange = (value: any) => {
+    if (onObjectPropertyChange != null) {
+      onObjectPropertyChange(value);
+      return;
+    }
+    if (onArrayItemChange != null) {
+      onArrayItemChange(value);
+      return;
+    }
+    onChangeParam(parentInputs, param.name, value);
+  };
+
+  const onObjectParentChange = (property: string, value: any) => {
+    const newObj = { ...object, [property]: value };
+    setObject({ ...object, [property]: value });
+    onInputChange(newObj);
+  };
+
+  const onArrayParentChange = (arrayIndex: number, value: any) => {
+    const newArray = array.map((item, i) => {
+      if (arrayIndex === i) {
+        return { ...item, value };
+      }
+      return item;
+    });
+    setArray(newArray);
+    onInputChange(newArray.map((item) => item.value));
+  };
+
+  const onAddArrayItem = () => {
+    const newArray = [
+      ...array,
+      { param: { ...param, type: getArrayType(param.type) }, value: null },
+    ];
+    setArray(newArray);
+    onInputChange(newArray.map((item) => item.value));
+  };
+
+  const onUpdateArray = (newArray: any) => {
+    setArray(newArray);
+    let inputValue = newArray.length > 0 ? newArray : undefined;
+    onInputChange(inputValue?.map((item: any) => item.value));
+  };
+
+  if (lowerCaseParamType === "boolean") {
+    InputField = (
+      <div className="relative">
+        <select
+          className="w-full py-0.5 px-2 rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 cursor-pointer"
+          onChange={(e) => {
+            const selection = e.target.value;
+            onInputChange(selection === "true");
+          }}
+        >
+          <option disabled selected>
+            Select
+          </option>
+          <option>true</option>
+          <option>false</option>
+        </select>
+        <svg
+          className="absolute right-2 top-[7px] h-3 fill-slate-600 dark:fill-slate-400"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 384 512"
+        >
+          <path d="M192 384c-8.188 0-16.38-3.125-22.62-9.375l-160-160c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L192 306.8l137.4-137.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-160 160C208.4 380.9 200.2 384 192 384z" />
+        </svg>
+      </div>
+    );
+  } else if (
+    lowerCaseParamType === "integer" ||
+    lowerCaseParamType === "number"
+  ) {
+    InputField = (
+      <input
+        className="w-full py-0.5 px-2 rounded border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200"
+        type="number"
+        placeholder={param.placeholder}
+        value={value as any}
+        onChange={(e) => onInputChange(parseInt(e.target.value, 10))}
+      />
+    );
+  } else if (lowerCaseParamType === "file" || lowerCaseParamType === "files") {
+    InputField = (
+      <button className="relative flex items-center px-2 w-full h-7 rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 border-dashed hover:bg-slate-50 dark:hover:bg-slate-800">
+        <input
+          className="z-10 absolute inset-0 opacity-0 cursor-pointer"
+          type="file"
+          onChange={(event) => {
+            if (event.target.files == null) {
+              return;
+            }
+            onInputChange(event.target.files[0]);
+          }}
+        />
+        <svg
+          className="absolute right-2 top-[7px] h-3 fill-slate-500 dark:fill-slate-400 bg-border-slate-700"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 512 512"
+        >
+          <path d="M105.4 182.6c12.5 12.49 32.76 12.5 45.25 .001L224 109.3V352c0 17.67 14.33 32 32 32c17.67 0 32-14.33 32-32V109.3l73.38 73.38c12.49 12.49 32.75 12.49 45.25-.001c12.49-12.49 12.49-32.75 0-45.25l-128-128C272.4 3.125 264.2 0 256 0S239.6 3.125 233.4 9.375L105.4 137.4C92.88 149.9 92.88 170.1 105.4 182.6zM480 352h-160c0 35.35-28.65 64-64 64s-64-28.65-64-64H32c-17.67 0-32 14.33-32 32v96c0 17.67 14.33 32 32 32h448c17.67 0 32-14.33 32-32v-96C512 366.3 497.7 352 480 352zM432 456c-13.2 0-24-10.8-24-24c0-13.2 10.8-24 24-24s24 10.8 24 24C456 445.2 445.2 456 432 456z" />
+        </svg>
+        {value != null && (value as any)[param.name] != null ? (
+          <span className="w-full truncate">
+            {(value as any)[param.name].name}
+          </span>
+        ) : (
+          "Choose file"
+        )}
+      </button>
+    );
+  } else if (isObject && !isArray) {
+    InputField = (
+      <button
+        className="relative flex items-center w-full h-6 justify-end "
+        onClick={() => setIsExpandedProperties(!isExpandedProperties)}
+      >
+        <span className="fill-slate-500 dark:fill-slate-400 group-hover:fill-slate-700 dark:group-hover:fill-slate-200">
+          {isExpandedProperties ? (
+            <svg
+              className="h-3 w-3"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+            >
+              <path d="M473 7c-9.4-9.4-24.6-9.4-33.9 0l-87 87L313 55c-6.9-6.9-17.2-8.9-26.2-5.2S272 62.3 272 72V216c0 13.3 10.7 24 24 24H440c9.7 0 18.5-5.8 22.2-14.8s1.7-19.3-5.2-26.2l-39-39 87-87c9.4-9.4 9.4-24.6 0-33.9L473 7zM216 272H72c-9.7 0-18.5 5.8-22.2 14.8s-1.7 19.3 5.2 26.2l39 39L7 439c-9.4 9.4-9.4 24.6 0 33.9l32 32c9.4 9.4 24.6 9.4 33.9 0l87-87 39 39c6.9 6.9 17.2 8.9 26.2 5.2s14.8-12.5 14.8-22.2V296c0-13.3-10.7-24-24-24z" />
+            </svg>
+          ) : (
+            <svg
+              className="h-3 w-3"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+            >
+              <path d="M344 0H488c13.3 0 24 10.7 24 24V168c0 9.7-5.8 18.5-14.8 22.2s-19.3 1.7-26.2-5.2l-39-39-87 87c-9.4 9.4-24.6 9.4-33.9 0l-32-32c-9.4-9.4-9.4-24.6 0-33.9l87-87L327 41c-6.9-6.9-8.9-17.2-5.2-26.2S334.3 0 344 0zM184 496H40c-13.3 0-24-10.7-24-24V328c0-9.7 5.8-18.5 14.8-22.2s19.3-1.7 26.2 5.2l39 39 87-87c9.4-9.4 24.6-9.4 33.9 0l32 32c9.4 9.4 9.4 24.6 0 33.9l-87 87 39 39c6.9 6.9 8.9 17.2 5.2 26.2s-12.5 14.8-22.2 14.8z" />
+            </svg>
+          )}
+        </span>
+      </button>
+    );
+  } else if (isArray) {
+    InputField = array.length === 0 && (
+      <AddArrayItemButton onClick={onAddArrayItem} />
+    );
+  } else if (param.enum) {
+    InputField = (
+      <div className="relative">
+        <select
+          className="w-full py-0.5 px-2 rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 hover:border-slate-400 dark:hover:border-slate-500 cursor-pointer"
+          onChange={(e) => {
+            const selection = e.target.value;
+            onInputChange(selection);
+          }}
+        >
+          <option disabled selected>
+            Select
+          </option>
+          {param.enum.map((enumValue) => (
+            <option>{enumValue}</option>
+          ))}
+        </select>
+        <svg
+          className="absolute right-2 top-[7px] h-3 fill-slate-500 dark:fill-slate-400"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 384 512"
+        >
+          <path d="M192 384c-8.188 0-16.38-3.125-22.62-9.375l-160-160c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L192 306.8l137.4-137.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-160 160C208.4 380.9 200.2 384 192 384z" />
+        </svg>
+      </div>
+    );
+  } else {
+    InputField = (
+      <input
+        className="w-full py-0.5 px-2 rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200"
+        type="text"
+        placeholder={param.placeholder}
+        value={value as any}
+        onChange={(e) => onInputChange(e.target.value)}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={clsx(
+        "text-[0.84rem]",
+        ((isObject && isExpandedProperties) || array.length > 0) &&
+          "px-3 py-2 -mx-1.5 border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 rounded-md"
+      )}
+    >
+      <div className="flex items-center space-x-2 group">
+        <div
+          className={clsx(
+            "flex items-center flex-1 font-mono text-slate-600 dark:text-slate-300",
+            isObject && "cursor-pointer",
+            onDeleteArrayItem && "invisible" // Array items don't have parameter names
+          )}
+          onClick={() =>
+            isObject && setIsExpandedProperties(!isExpandedProperties)
+          }
+        >
+          {param.name}
+          {param.required && (
+            <span className="text-red-600 dark:text-red-400">*</span>
+          )}
+        </div>
+        <div
+          className={clsx(
+            "flex-initial",
+            onDeleteArrayItem
+              ? "w-[calc(40%-1.05rem)] sm:w-[calc(33%-1.05rem)]"
+              : "w-2/5 sm:w-1/3"
+          )}
+        >
+          {InputField}
+        </div>
+        {onDeleteArrayItem && (
+          <button
+            className="py-1 fill-red-600 dark:fill-red-400 hover:fill-red-800 dark:hover:fill-red-200"
+            onClick={onDeleteArrayItem}
+          >
+            <svg
+              className="h-3"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 448 512"
+            >
+              <path d="M424 80C437.3 80 448 90.75 448 104C448 117.3 437.3 128 424 128H412.4L388.4 452.7C385.9 486.1 358.1 512 324.6 512H123.4C89.92 512 62.09 486.1 59.61 452.7L35.56 128H24C10.75 128 0 117.3 0 104C0 90.75 10.75 80 24 80H93.82L130.5 24.94C140.9 9.357 158.4 0 177.1 0H270.9C289.6 0 307.1 9.358 317.5 24.94L354.2 80H424zM177.1 48C174.5 48 171.1 49.34 170.5 51.56L151.5 80H296.5L277.5 51.56C276 49.34 273.5 48 270.9 48H177.1zM364.3 128H83.69L107.5 449.2C108.1 457.5 115.1 464 123.4 464H324.6C332.9 464 339.9 457.5 340.5 449.2L364.3 128z" />
+            </svg>
+          </button>
+        )}
+      </div>
+      {/* Properties extension */}
+      {isExpandedProperties && param.properties && (
+        <div className="mt-1 pt-2 pb-1 border-t border-slate-100 dark:border-slate-700 space-y-2">
+          {param.properties.map((property) => (
+            <ApiInput
+              key={property.name}
+              param={property}
+              value={(value as any)[property.name]}
+              onChangeParam={onChangeParam}
+              parentInputs={[...parentInputs, param.name]}
+              onObjectPropertyChange={(value: any) =>
+                onObjectParentChange(property.name, value)
+              }
+            />
+          ))}
+        </div>
+      )}
+      {/* Array extension */}
+      {array.length > 0 && (
+        <div
+          className={clsx(
+            "mt-1 pt-2 pb-1 space-y-2",
+            !isObject && "border-t border-slate-100 dark:border-slate-700"
+          )}
+        >
+          {array.map((item, i) => (
+            <ApiInput
+              key={item.param.name + i}
+              param={item.param}
+              value={item.value}
+              onChangeParam={onChangeParam}
+              onArrayItemChange={(value: any) => onArrayParentChange(i, value)}
+              onDeleteArrayItem={() =>
+                onUpdateArray(array.filter((_, j) => i !== j))
+              }
+            />
+          ))}
+          <div className="flex items-center justify-end space-x-2 group">
+            <div className="flex-initial w-2/5 sm:w-1/3">
+              <AddArrayItemButton onClick={onAddArrayItem} />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/Api/ApiPlayground.tsx
+++ b/src/Api/ApiPlayground.tsx
@@ -1,0 +1,152 @@
+import clsx from "clsx";
+import { ReactNode, useState } from "react";
+import {
+  getMethodBgColor,
+  getMethodTextColor,
+  getMethodBorderColor,
+  getMethodBgHoverColor,
+} from "../utils/apiPlaygroundColors";
+import { ApiInput } from "./ApiInput";
+import { ApiInputValue, ParamGroup, RequestMethods } from "./types";
+
+export function ApiPlayground({
+  method,
+  paramGroups,
+  paramValues,
+  isSendingRequest,
+  onChangeParam,
+  onSendRequest,
+  header,
+  response,
+}: {
+  /** Request method. */
+  method: RequestMethods;
+
+  /** Array of param groups to show as tabs for input. */
+  paramGroups: ParamGroup[];
+
+  /** Values to show in the ApiInputs. Key is the param group name. */
+  paramValues: Record<string, Record<string, any>>;
+
+  /** Whether you are currently sending a request.
+   *  The Send Request button is disabled and the response is hidden while this is true. */
+  isSendingRequest: boolean;
+
+  /** Callback when the user changes a parameter's value. */
+  onChangeParam: (
+    paramGroupName: string,
+    parentInputs: string[],
+    paramName: string,
+    paramValue: ApiInputValue
+  ) => void;
+
+  /** Callback when the user clicks the Send Request button. */
+  onSendRequest: () => void;
+
+  /** Header to show above parameter inputs. */
+  header?: ReactNode;
+
+  /** Response to show underneath the playground.
+   *  This component does not automatically syntax highlight code. */
+  response?: ReactNode;
+}) {
+  // const onChangeParam = (
+  //   paramGroup: string,
+  //   param: string,
+  //   value: ApiInputValue,
+  //   path: string[]
+  // ) => {
+  //   const newParamGroup = {
+  //     ...inputData[paramGroup],
+  //     ...set(inputData[paramGroup], [...path, param], value),
+  //   };
+  //   setInputData({ ...inputData, [paramGroup]: newParamGroup });
+  // };
+
+  const [currentActiveParamGroup, setCurrentActiveParamGroup] =
+    useState<ParamGroup>(paramGroups[0]);
+
+  return (
+    <div className="mt-4 border border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-800 rounded-md truncate">
+      <div className="px-3.5 pt-3.5 pb-4">
+        {header}
+        <div className="text-sm">
+          <div className="block">
+            <div className="border-b border-slate-200 dark:border-slate-600">
+              <nav className="-mb-px flex space-x-4" aria-label="Tabs">
+                {paramGroups.map((paramGroup: ParamGroup) => (
+                  <button
+                    key={paramGroup.name}
+                    className={clsx(
+                      currentActiveParamGroup?.name === paramGroup.name
+                        ? `${getMethodTextColor(method)} ${getMethodBorderColor(
+                            method
+                          )}`
+                        : "border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300 dark:text-slate-400 dark:hover:text-slate-200",
+                      "whitespace-nowrap py-2 border-b-2 font-medium text-[0.84rem]"
+                    )}
+                    onClick={() => setCurrentActiveParamGroup(paramGroup)}
+                  >
+                    {paramGroup.name}
+                  </button>
+                ))}
+              </nav>
+            </div>
+          </div>
+          <div className="mt-4 space-y-2">
+            {currentActiveParamGroup?.params.map((param, i) => (
+              <ApiInput
+                key={`${param.name}${i}`}
+                param={param}
+                value={
+                  paramValues[currentActiveParamGroup.name][param.name] ?? ""
+                }
+                onChangeParam={(
+                  parentInputs: string[],
+                  paramName: string,
+                  paramValue: ApiInputValue
+                ) =>
+                  onChangeParam(
+                    currentActiveParamGroup.name,
+                    parentInputs,
+                    paramName,
+                    paramValue
+                  )
+                }
+              />
+            ))}
+          </div>
+          <button
+            className={clsx(
+              "flex items-center py-1.5 px-3 rounded text-white font-medium space-x-2",
+              getMethodBgColor(method),
+              getMethodBgHoverColor(method),
+              currentActiveParamGroup && "mt-4"
+            )}
+            disabled={isSendingRequest}
+            onClick={onSendRequest}
+          >
+            <svg
+              className="fill-white h-3"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 384 512"
+            >
+              <path d="M361 215C375.3 223.8 384 239.3 384 256C384 272.7 375.3 288.2 361 296.1L73.03 472.1C58.21 482 39.66 482.4 24.52 473.9C9.377 465.4 0 449.4 0 432V80C0 62.64 9.377 46.63 24.52 38.13C39.66 29.64 58.21 29.99 73.03 39.04L361 215z" />
+            </svg>
+            <div>{!isSendingRequest ? "Send Request" : "Sending..."}</div>
+          </button>
+        </div>
+      </div>
+      {!isSendingRequest ? response : null}
+    </div>
+  );
+}
+
+// <div className="py-3 px-3 max-h-60 whitespace-pre overflow-scroll border-t border-slate-200 dark:border-slate-700  dark:text-slate-300 font-mono text-xs leading-5">
+//           <span
+//             className="language-json max-h-72 overflow-scroll"
+//             dangerouslySetInnerHTML={{
+//               __html: apiResponse,
+//             }}
+//           />
+//         </div>

--- a/src/Api/BaseUrlDropdown.tsx
+++ b/src/Api/BaseUrlDropdown.tsx
@@ -1,0 +1,49 @@
+export function BaseUrlDropdown({
+  baseUrls,
+  defaultValue,
+  onChange,
+}: {
+  /** Array of base URLs to select from. Component is hidden when the array is empty or only has one value. */
+  baseUrls: string[];
+
+  /** Initially selected base URL. */
+  defaultValue: string | undefined;
+
+  /** Function called when the user selects a different base URL. */
+  onChange: (baseUrl: string) => void;
+}) {
+  if (baseUrls.length <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="border-slate-400 dark:border-slate-400 relative select-none align-middle inline-flex rounded-md -top-px mx-1 w-5 h-[1.125rem] bg-white hover:bg-slate-100 dark:bg-slate-700 dark:hover:bg-slate-600 border hover:border-slate-400 dark:hover:border-slate-400 focus:outline-none cursor-pointer">
+      <select
+        aria-label="Select API base"
+        aria-expanded="false"
+        className="z-10 absolute inset-0 opacity-0 cursor-pointer"
+        onChange={(e) => onChange(e.target.value)}
+        defaultValue={defaultValue}
+      >
+        <option disabled>Select API base</option>
+        {baseUrls.map((baseUrl) => (
+          <option key={baseUrl}>{baseUrl}</option>
+        ))}
+      </select>
+      <svg
+        width="20"
+        height="20"
+        fill="none"
+        className="transform absolute -top-0.5 -left-px rotate-90"
+      >
+        <path
+          className="stroke-slate-700 dark:stroke-slate-100"
+          d="M9 7l3 3-3 3"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        ></path>
+      </svg>
+    </div>
+  );
+}

--- a/src/Api/RequestMethodBubble.tsx
+++ b/src/Api/RequestMethodBubble.tsx
@@ -1,0 +1,14 @@
+import clsx from "clsx";
+import { getMethodBgColor } from "../utils/apiPlaygroundColors";
+import { RequestMethods } from "./types";
+
+export const RequestMethodBubble = ({ method }: { method: RequestMethods }) => (
+  <span
+    className={clsx(
+      "inline-block text-white font-bold px-1.5 rounded-md text-[0.95rem]",
+      getMethodBgColor(method)
+    )}
+  >
+    {method}
+  </span>
+);

--- a/src/Api/RequestPathHeader.tsx
+++ b/src/Api/RequestPathHeader.tsx
@@ -1,0 +1,40 @@
+import { BaseUrlDropdown } from "./BaseUrlDropdown";
+import { RequestMethodBubble } from "./RequestMethodBubble";
+import { RequestMethods } from "./types";
+
+export const RequestPathHeader = ({
+  method,
+  path,
+  baseUrls,
+  defaultBaseUrl,
+  onBaseUrlChange,
+}: {
+  /** Request method. */
+  method: RequestMethods;
+
+  /** Path text to show beside the request method bubble. */
+  path: string;
+
+  /** Array of baseUrls to select from. Dropdown is hidden when there are zero or one options. */
+  baseUrls: string[];
+
+  /** What value of baseUrl the dropdown should show as selected before the user has changed the selection. */
+  defaultBaseUrl?: string;
+
+  /** Callback when the user changes the baseUrl in the dropdown. */
+  onBaseUrlChange: (baseUrl: string) => void;
+}) => (
+  <div className="text-sm md:text-base flex items-center space-x-2 mb-2">
+    <RequestMethodBubble method={method} />
+    <BaseUrlDropdown
+      baseUrls={baseUrls}
+      defaultValue={defaultBaseUrl}
+      onChange={onBaseUrlChange}
+    />
+    <div className="font-mono text-[0.95rem] overflow-auto">
+      <p className="inline-block text-slate-700 dark:text-slate-100 font-semibold">
+        {path}
+      </p>
+    </div>
+  </div>
+);

--- a/src/Api/index.ts
+++ b/src/Api/index.ts
@@ -1,0 +1,4 @@
+import { ApiPlayground } from "./ApiPlayground";
+import { BaseUrlDropdown } from "./BaseUrlDropdown";
+
+export { ApiPlayground, BaseUrlDropdown };

--- a/src/Api/index.ts
+++ b/src/Api/index.ts
@@ -1,4 +1,11 @@
 import { ApiPlayground } from "./ApiPlayground";
+import { RequestMethodBubble } from "./RequestMethodBubble";
+import { RequestPathHeader } from "./RequestPathHeader";
 import { BaseUrlDropdown } from "./BaseUrlDropdown";
 
-export { ApiPlayground, BaseUrlDropdown };
+export {
+  ApiPlayground,
+  RequestMethodBubble,
+  RequestPathHeader,
+  BaseUrlDropdown,
+};

--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -1,0 +1,42 @@
+export type RequestMethods =
+  | "GET"
+  | "POST"
+  | "PUT"
+  | "DELETE"
+  | "PATCH"
+  | "COPY" // "COPY" and everything below has a grey color
+  | "HEAD"
+  | "OPTIONS"
+  | "LINK"
+  | "UNLINK"
+  | "PURGE"
+  | "LOCK"
+  | "UNLOCK"
+  | "PROPFIND"
+  | "VIEW";
+
+export type ParamGroup = {
+  name: string;
+  params: Param[];
+};
+
+export type Param = {
+  name: string;
+  placeholder?: string;
+  required?: boolean;
+  type?: string;
+  enum?: string[];
+  format?: string;
+  group?: string;
+  properties?: Param[];
+};
+
+export type ApiInputValue =
+  | string
+  | number
+  | boolean
+  | File
+  | string[]
+  | number[]
+  | boolean[]
+  | File[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { PillSelect } from "./PillSelect";
 import { Tab, Tabs } from "./Tabs";
 import { Tooltip } from "./Tooltip";
 import { Expandable } from "./Expandable";
+import { ApiPlayground } from "./Api";
 
 // Import Tailwind
 import "./css/globals.css";
@@ -17,6 +18,7 @@ import "./css/globals.css";
 export {
   Accordion,
   AccordionGroup,
+  ApiPlayground,
   Button,
   Card,
   CardGroup,

--- a/src/stories/Api/ApiInput.stories.tsx
+++ b/src/stories/Api/ApiInput.stories.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { ApiInput } from "../../Api/ApiInput";
+import { ApiInputValue } from "../../Api/types";
+
+export default {
+  title: "Api/ApiInput",
+  component: ApiInput,
+} as ComponentMeta<typeof ApiInput>;
+
+const Template: ComponentStory<typeof ApiInput> = (args) => (
+  <div className="max-w-md">
+    <ApiInput
+      param={args.param}
+      value={args.value}
+      onChangeParam={(
+        parentInputs: string[],
+        paramName: string,
+        value: ApiInputValue
+      ) => {
+        console.log(value);
+      }}
+      // Storybook automatically adds a blank function if we don't do this, and our code
+      // shows a garbage can when the delete function exists.
+      onDeleteArrayItem={undefined}
+    />
+  </div>
+);
+
+export const TextInputWithPlaceholder = Template.bind({});
+TextInputWithPlaceholder.args = {
+  param: {
+    name: "Text Input",
+    type: "text",
+    placeholder: "Placeholder Value",
+  },
+  value: "",
+};
+
+export const ArrayInput = Template.bind({});
+ArrayInput.args = {
+  param: {
+    name: "Array Input",
+    type: "array",
+  },
+  value: [
+    { param: { name: "This text should be hidden", type: "text" }, value: 1 },
+    { param: { name: "This text should be hidden", type: "text" }, value: 2 },
+  ],
+};
+
+export const ObjectInput = Template.bind({});
+ObjectInput.args = {
+  param: {
+    name: "Object Input",
+    type: "object",
+    properties: [
+      { name: "Example Property Name" },
+      { name: "camelCasePropertyName" },
+    ],
+  },
+  value: {
+    "Example Property Name": 123,
+    camelCasePropertyName: "Example string value",
+  },
+};

--- a/src/stories/Api/ApiPlayground.stories.tsx
+++ b/src/stories/Api/ApiPlayground.stories.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { ApiPlayground, RequestPathHeader } from "../../Api";
+
+export default {
+  title: "Api/ApiPlayground",
+  component: ApiPlayground,
+} as ComponentMeta<typeof ApiPlayground>;
+
+const Template: ComponentStory<typeof ApiPlayground> = (args) => (
+  <ApiPlayground {...args} />
+);
+
+export const HeaderButNoResponse = Template.bind({});
+HeaderButNoResponse.args = {
+  method: "GET",
+  header: (
+    <RequestPathHeader
+      method="GET"
+      path="/api/example/path"
+      baseUrls={["Base URL 1", "Base URL 2"]}
+      onBaseUrlChange={(baseUrl) => {
+        console.log(baseUrl);
+      }}
+    />
+  ),
+};
+
+export const NoHeader = Template.bind({});
+NoHeader.args = {
+  method: "PATCH",
+};

--- a/src/stories/Api/ApiPlayground.stories.tsx
+++ b/src/stories/Api/ApiPlayground.stories.tsx
@@ -25,9 +25,15 @@ HeaderButNoResponse.args = {
       }}
     />
   ),
+  paramGroups: [],
+  paramValues: [],
+  isSendingRequest: false,
 };
 
 export const NoHeader = Template.bind({});
 NoHeader.args = {
   method: "PATCH",
+  paramGroups: [],
+  paramValues: [],
+  isSendingRequest: false,
 };

--- a/src/stories/Api/BaseUrlDropdown.stories.tsx
+++ b/src/stories/Api/BaseUrlDropdown.stories.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { BaseUrlDropdown } from "../../Api";
+
+export default {
+  title: "Api/BaseUrlDropdown",
+  component: BaseUrlDropdown,
+} as ComponentMeta<typeof BaseUrlDropdown>;
+
+const Template: ComponentStory<typeof BaseUrlDropdown> = (args) => {
+  const [_, setSelectedBaseUrl] = React.useState(args.baseUrls[0] ?? "");
+
+  // You can console.log(selectedBaseUrl) here to test the state is set correctly from onChange().
+  // We don't pass the selected value to the component because we don't need it. The <select> tag
+  // used internally tracks the state.
+
+  return (
+    <BaseUrlDropdown
+      baseUrls={args.baseUrls}
+      defaultValue={args.baseUrls[0]}
+      onChange={(baseUrl) => setSelectedBaseUrl(baseUrl)}
+    />
+  );
+};
+
+export const ThreeOptions = Template.bind({});
+ThreeOptions.args = {
+  baseUrls: ["Option 1", "Very Long Option 2", "Option 3"],
+};

--- a/src/stories/Api/RequestMethodBubble.stories.tsx
+++ b/src/stories/Api/RequestMethodBubble.stories.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { RequestMethodBubble } from "../../Api";
+
+export default {
+  title: "Api/RequestMethodBubble",
+  component: RequestMethodBubble,
+} as ComponentMeta<typeof RequestMethodBubble>;
+
+const Template: ComponentStory<typeof RequestMethodBubble> = (args) => (
+  <RequestMethodBubble {...args} />
+);
+
+export const GET = Template.bind({});
+GET.args = {
+  method: "GET",
+};
+
+export const POST = Template.bind({});
+POST.args = {
+  method: "POST",
+};
+
+export const PUT = Template.bind({});
+PUT.args = {
+  method: "PUT",
+};
+
+export const DELETE = Template.bind({});
+DELETE.args = {
+  method: "DELETE",
+};
+
+export const PATCH = Template.bind({});
+PATCH.args = {
+  method: "PATCH",
+};
+
+export const OPTIONS = Template.bind({});
+OPTIONS.args = {
+  method: "OPTIONS",
+};

--- a/src/stories/Api/RequestPathHeader.stories.tsx
+++ b/src/stories/Api/RequestPathHeader.stories.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { RequestPathHeader } from "../../Api";
+
+export default {
+  title: "Api/RequestPathHeader",
+  component: RequestPathHeader,
+} as ComponentMeta<typeof RequestPathHeader>;
+
+const Template: ComponentStory<typeof RequestPathHeader> = (args) => (
+  <RequestPathHeader
+    method={args.method}
+    path={args.path}
+    baseUrls={args.baseUrls}
+    defaultBaseUrl={args.baseUrls[0]}
+    onBaseUrlChange={(baseUrl) => console.log(baseUrl)}
+  />
+);
+
+export const MultipleBaseUrls = Template.bind({});
+MultipleBaseUrls.args = {
+  method: "GET",
+  path: "/api/example/path",
+  baseUrls: ["Base URL 1", "Base URL 2"],
+};

--- a/src/stories/Display/Callouts/Check.stories.tsx
+++ b/src/stories/Display/Callouts/Check.stories.tsx
@@ -1,14 +1,14 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Tip } from "../../Callouts";
+import { Check } from "../../../Callouts";
 
 export default {
-  title: "Display/Callouts/Tip",
-  component: Tip,
-} as ComponentMeta<typeof Tip>;
+  title: "Display/Callouts/Check",
+  component: Check,
+} as ComponentMeta<typeof Check>;
 
-const Template: ComponentStory<typeof Tip> = (args) => <Tip {...args} />;
+const Template: ComponentStory<typeof Check> = (args) => <Check {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/src/stories/Display/Callouts/Info.stories.tsx
+++ b/src/stories/Display/Callouts/Info.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Info } from "../../Callouts";
-import { CodeBlock } from "../../Code";
+import { Info } from "../../../Callouts";
+import { CodeBlock } from "../../../Code";
 
 export default {
   title: "Display/Callouts/Info",

--- a/src/stories/Display/Callouts/Note.stories.tsx
+++ b/src/stories/Display/Callouts/Note.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Note } from "../../Callouts";
-import { CodeBlock, CodeGroup } from "../../Code";
+import { Note } from "../../../Callouts";
+import { CodeBlock, CodeGroup } from "../../../Code";
 
 export default {
   title: "Display/Callouts/Note",

--- a/src/stories/Display/Callouts/Tip.stories.tsx
+++ b/src/stories/Display/Callouts/Tip.stories.tsx
@@ -1,14 +1,14 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Check } from "../../Callouts";
+import { Tip } from "../../../Callouts";
 
 export default {
-  title: "Display/Callouts/Check",
-  component: Check,
-} as ComponentMeta<typeof Check>;
+  title: "Display/Callouts/Tip",
+  component: Tip,
+} as ComponentMeta<typeof Tip>;
 
-const Template: ComponentStory<typeof Check> = (args) => <Check {...args} />;
+const Template: ComponentStory<typeof Tip> = (args) => <Tip {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/src/stories/Display/Callouts/Warning.stories.tsx
+++ b/src/stories/Display/Callouts/Warning.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Warning } from "../../Callouts";
+import { Warning } from "../../../Callouts";
 
 export default {
   title: "Display/Callouts/Warning",

--- a/src/stories/Display/Cards/Card.stories.tsx
+++ b/src/stories/Display/Cards/Card.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Card } from "../../Card";
+import { Card } from "../../../Card";
 
 export default {
   title: "Display/Cards/Card",

--- a/src/stories/Display/Cards/CardGroup.stories.tsx
+++ b/src/stories/Display/Cards/CardGroup.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { CardGroup } from "../../CardGroup";
-import { Card } from "../../Card";
+import { CardGroup } from "../../../CardGroup";
+import { Card } from "../../../Card";
 
 export default {
   title: "Display/Cards/CardGroup",

--- a/src/stories/Display/Frame.stories.tsx
+++ b/src/stories/Display/Frame.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Frame } from "../Frame";
+import { Frame } from "../../Frame";
 
 export default {
   title: "Display/Frame",

--- a/src/stories/Display/Param.stories.tsx
+++ b/src/stories/Display/Param.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { ParamField } from "../Param";
+import { ParamField } from "../../Param";
 
 export default {
   title: "Display/Param",

--- a/src/stories/Display/Tooltip.stories.tsx
+++ b/src/stories/Display/Tooltip.stories.tsx
@@ -10,7 +10,7 @@ export default {
 } as ComponentMeta<typeof Tooltip>;
 
 const Template: ComponentStory<typeof Tooltip> = (args) => (
-  <div className="ml-32 mt-32">
+  <div className="ml-16 mt-8">
     <Tooltip {...args} />
   </div>
 );

--- a/src/stories/Display/Tooltip.stories.tsx
+++ b/src/stories/Display/Tooltip.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Tooltip } from "../Tooltip";
-import { Button } from "../Button";
+import { Tooltip } from "../../Tooltip";
+import { Button } from "../../Button";
 
 export default {
   title: "Display/Tooltip",

--- a/src/stories/Interactive/Accordion.stories.tsx
+++ b/src/stories/Interactive/Accordion.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Accordion } from "../Accordion";
-import { ParamField } from "../Param";
+import { Accordion } from "../../Accordion";
+import { ParamField } from "../../Param";
 
 export default {
   title: "Interactive/Accordion",

--- a/src/stories/Interactive/Button.stories.tsx
+++ b/src/stories/Interactive/Button.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Button } from "../Button";
+import { Button } from "../../Button";
 
 export default {
   title: "Interactive/Button",

--- a/src/stories/Interactive/Code/CodeBlock.stories.tsx
+++ b/src/stories/Interactive/Code/CodeBlock.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Accordion } from "../../Accordion";
-import { CodeBlock } from "../../Code";
+import { Accordion } from "../../../Accordion";
+import { CodeBlock } from "../../../Code";
 
 export default {
   title: "Interactive/Code/CodeBlock",

--- a/src/stories/Interactive/Code/CodeGroup.stories.tsx
+++ b/src/stories/Interactive/Code/CodeGroup.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Accordion } from "../../Accordion";
-import { CodeBlock, CodeGroup } from "../../Code";
+import { Accordion } from "../../../Accordion";
+import { CodeBlock, CodeGroup } from "../../../Code";
 
 export default {
   title: "Interactive/Code/CodeGroup",

--- a/src/stories/Interactive/Expandable.stories.tsx
+++ b/src/stories/Interactive/Expandable.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Expandable } from "../Expandable";
-import { ParamField } from "../Param";
+import { Expandable } from "../../Expandable";
+import { ParamField } from "../../Param";
 
 export default {
   title: "Interactive/Expandable",

--- a/src/stories/Interactive/PillSelect.stories.tsx
+++ b/src/stories/Interactive/PillSelect.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { PillSelect } from "../PillSelect";
+import { PillSelect } from "../../PillSelect";
 
 export default {
   title: "Interactive/PillSelect",

--- a/src/stories/Interactive/Tab.stories.tsx
+++ b/src/stories/Interactive/Tab.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Tab } from "../Tabs";
+import { Tab } from "../../Tabs";
 
 export default {
   title: "Display/Tab",

--- a/src/stories/Interactive/Tabs.stories.tsx
+++ b/src/stories/Interactive/Tabs.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Tab, Tabs } from "../Tabs";
+import { Tab, Tabs } from "../../Tabs";
 
 export default {
   title: "Display/Tabs",

--- a/src/utils/apiPlaygroundColors.ts
+++ b/src/utils/apiPlaygroundColors.ts
@@ -1,0 +1,67 @@
+export const getMethodBgColor = (method?: string) => {
+  switch (method?.toUpperCase()) {
+    case "GET":
+      return "bg-green-600";
+    case "POST":
+      return "bg-blue-600";
+    case "PUT":
+      return "bg-yellow-600";
+    case "DELETE":
+      return "bg-red-600";
+    case "PATCH":
+      return "bg-orange-600";
+    default:
+      return "bg-slate-600";
+  }
+};
+
+export const getMethodBgHoverColor = (method?: string) => {
+  switch (method?.toUpperCase()) {
+    case "GET":
+      return "hover:bg-green-800 disabled:bg-green-700";
+    case "POST":
+      return "hover:bg-blue-800 disabled:bg-blue-700";
+    case "PUT":
+      return "hover:bg-yellow-800 disabled:bg-yellow-700";
+    case "DELETE":
+      return "hover:bg-red-800 disabled:bg-red-700";
+    case "PATCH":
+      return "hover:bg-orange-800 disabled:bg-orange-700";
+    default:
+      return "hover:bg-slate-800 disabled:bg-slate-700";
+  }
+};
+
+export const getMethodTextColor = (method?: string) => {
+  switch (method?.toUpperCase()) {
+    case "GET":
+      return "text-green-600 dark:text-green-500";
+    case "POST":
+      return "text-blue-600 dark:text-blue-500";
+    case "PUT":
+      return "text-yellow-600 dark:text-yellow-500";
+    case "DELETE":
+      return "text-red-600 dark:text-red-500";
+    case "PATCH":
+      return "text-orange-600 dark:text-orange-500";
+    default:
+      return "text-slate-600 dark:text-slate-500";
+  }
+};
+
+export const getMethodBorderColor = (method?: string) => {
+  switch (method?.toUpperCase()) {
+    case "GET":
+      return "border-green-600 dark:border-green-500";
+    case "POST":
+      return "border-blue-600 dark:border-blue-500";
+    case "PUT":
+      return "border-yellow-600 dark:border-yellow-500";
+    case "DELETE":
+      return "border-red-600 dark:border-red-500";
+    case "PATCH":
+      return "border-orange-600 dark:border-orange-500";
+    default:
+      return "border-slate-600 dark:border-slate-500";
+  }
+};


### PR DESCRIPTION
Breaks up the API Playground into granular components and adds each of them to Storybook.

I'll make another PR tomorrow that makes the API Playground functional. Test this PR by viewing the stories for the components that make up the playground.