### PR TITLE
Expose inputs outside playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mintlify/components",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mintlify/components",
-      "version": "0.1.52",
+      "version": "0.1.53",
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mintlify/components",
-  "version": "0.1.53",
+  "version": "0.1.55",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mintlify/components",
-      "version": "0.1.53",
+      "version": "0.1.55",
       "license": "MIT",
       "dependencies": {
         "@headlessui/react": "^1.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@headlessui/react": "^1.7.3",
         "assert": "^2.0.0",
         "clsx": "^1.1.1",
-        "is-absolute-url": "^4.0.1"
+        "is-absolute-url": "^4.0.1",
+        "lodash.set": "^4.3.2"
       },
       "devDependencies": {
         "@babel/core": "^7.18.13",
@@ -29,6 +30,7 @@
         "@storybook/react": "^6.5.13",
         "@storybook/testing-library": "^0.0.13",
         "@tailwindcss/typography": "^0.5.7",
+        "@types/lodash.set": "^4.3.7",
         "@types/react": "^18.0.21",
         "autoprefixer": "^10.4.8",
         "babel-loader": "^8.2.5",
@@ -9862,6 +9864,15 @@
       "integrity": "sha512-kb9/98N6X8gyME9Cf7YaqIMvYGnBSWqEci6tiettE6iJWH1XdJz/PO8LB0GtLCG7x8dU3KWhZT+lA1a35127tA==",
       "dev": true
     },
+    "node_modules/@types/lodash.set": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.set/-/lodash.set-4.3.7.tgz",
+      "integrity": "sha512-bS5Wkg/nrT82YUfkNYPSccFrNZRL+irl7Yt4iM6OTSQ0VZJED2oUIVm15NkNtUAQ8SRhCe+axqERUV6MJgkeEg==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
@@ -17217,6 +17228,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -31921,6 +31937,15 @@
       "integrity": "sha512-kb9/98N6X8gyME9Cf7YaqIMvYGnBSWqEci6tiettE6iJWH1XdJz/PO8LB0GtLCG7x8dU3KWhZT+lA1a35127tA==",
       "dev": true
     },
+    "@types/lodash.set": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.set/-/lodash.set-4.3.7.tgz",
+      "integrity": "sha512-bS5Wkg/nrT82YUfkNYPSccFrNZRL+irl7Yt4iM6OTSQ0VZJED2oUIVm15NkNtUAQ8SRhCe+axqERUV6MJgkeEg==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mdast": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
@@ -37705,6 +37730,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
     },
     "lodash.uniq": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@storybook/react": "^6.5.13",
     "@storybook/testing-library": "^0.0.13",
     "@tailwindcss/typography": "^0.5.7",
+    "@types/lodash.set": "^4.3.7",
     "@types/react": "^18.0.21",
     "autoprefixer": "^10.4.8",
     "babel-loader": "^8.2.5",
@@ -72,6 +73,7 @@
     "@headlessui/react": "^1.7.3",
     "assert": "^2.0.0",
     "clsx": "^1.1.1",
-    "is-absolute-url": "^4.0.1"
+    "is-absolute-url": "^4.0.1",
+    "lodash.set": "^4.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/components",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "description": "Open-source library of UI components made with React and TailwindCSS.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/Api/ApiPlayground.tsx
+++ b/src/Api/ApiPlayground.tsx
@@ -59,7 +59,11 @@ export function ApiPlayground({
   ) => {
     const newParamGroup = {
       ...paramValues[paramGroupName],
-      ...set(paramValues[paramGroupName], [...parentInputs, paramName], value),
+      ...set(
+        paramValues[paramGroupName] ?? {},
+        [...parentInputs, paramName],
+        value
+      ),
     };
     onChangeParamValues({ ...paramValues, [paramGroupName]: newParamGroup });
   };

--- a/src/Api/ApiPlayground.tsx
+++ b/src/Api/ApiPlayground.tsx
@@ -97,7 +97,7 @@ export function ApiPlayground({
                 key={`${param.name}${i}`}
                 param={param}
                 value={
-                  paramValues[currentActiveParamGroup.name][param.name] ?? ""
+                  paramValues[currentActiveParamGroup.name]?.[param.name] ?? ""
                 }
                 onChangeParam={(
                   parentInputs: string[],

--- a/src/Api/ApiPlayground.tsx
+++ b/src/Api/ApiPlayground.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import set from "lodash.set";
 import { ReactNode, useState } from "react";
 import {
   getMethodBgColor,
@@ -14,7 +15,7 @@ export function ApiPlayground({
   paramGroups,
   paramValues,
   isSendingRequest,
-  onChangeParam,
+  onChangeParamValues,
   onSendRequest,
   header,
   response,
@@ -33,11 +34,8 @@ export function ApiPlayground({
   isSendingRequest: boolean;
 
   /** Callback when the user changes a parameter's value. */
-  onChangeParam: (
-    paramGroupName: string,
-    parentInputs: string[],
-    paramName: string,
-    paramValue: ApiInputValue
+  onChangeParamValues: (
+    paramValues: Record<string, Record<string, any>>
   ) => void;
 
   /** Callback when the user clicks the Send Request button. */
@@ -50,21 +48,21 @@ export function ApiPlayground({
    *  This component does not automatically syntax highlight code. */
   response?: ReactNode;
 }) {
-  // const onChangeParam = (
-  //   paramGroup: string,
-  //   param: string,
-  //   value: ApiInputValue,
-  //   path: string[]
-  // ) => {
-  //   const newParamGroup = {
-  //     ...inputData[paramGroup],
-  //     ...set(inputData[paramGroup], [...path, param], value),
-  //   };
-  //   setInputData({ ...inputData, [paramGroup]: newParamGroup });
-  // };
-
   const [currentActiveParamGroup, setCurrentActiveParamGroup] =
     useState<ParamGroup>(paramGroups[0]);
+
+  const setParamInObject = (
+    paramGroupName: string,
+    parentInputs: string[],
+    paramName: string,
+    value: ApiInputValue
+  ) => {
+    const newParamGroup = {
+      ...paramValues[paramGroupName],
+      ...set(paramValues[paramGroupName], [...parentInputs, paramName], value),
+    };
+    onChangeParamValues({ ...paramValues, [paramGroupName]: newParamGroup });
+  };
 
   return (
     <div className="mt-4 border border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-800 rounded-md truncate">
@@ -106,7 +104,7 @@ export function ApiPlayground({
                   paramName: string,
                   paramValue: ApiInputValue
                 ) =>
-                  onChangeParam(
+                  setParamInObject(
                     currentActiveParamGroup.name,
                     parentInputs,
                     paramName,

--- a/src/Api/ApiPlayground.tsx
+++ b/src/Api/ApiPlayground.tsx
@@ -139,12 +139,3 @@ export function ApiPlayground({
     </div>
   );
 }
-
-// <div className="py-3 px-3 max-h-60 whitespace-pre overflow-scroll border-t border-slate-200 dark:border-slate-700  dark:text-slate-300 font-mono text-xs leading-5">
-//           <span
-//             className="language-json max-h-72 overflow-scroll"
-//             dangerouslySetInnerHTML={{
-//               __html: apiResponse,
-//             }}
-//           />
-//         </div>

--- a/src/Api/ApiPlayground.tsx
+++ b/src/Api/ApiPlayground.tsx
@@ -6,7 +6,7 @@ import {
   getMethodBorderColor,
   getMethodBgHoverColor,
 } from "../utils/apiPlaygroundColors";
-import { ApiInput } from "./ApiInput";
+import { ApiInput } from "./inputs/ApiInput";
 import { ApiInputValue, ParamGroup, RequestMethods } from "./types";
 
 export function ApiPlayground({

--- a/src/Api/RequestPathHeader.tsx
+++ b/src/Api/RequestPathHeader.tsx
@@ -16,10 +16,10 @@ export const RequestPathHeader = ({
   path: string;
 
   /** Array of baseUrls to select from. Dropdown is hidden when there are zero or one options. */
-  baseUrls: string[] | undefined;
+  baseUrls?: string[];
 
   /** What value of baseUrl the dropdown should show as selected before the user has changed the selection. */
-  defaultBaseUrl?: string | undefined;
+  defaultBaseUrl?: string;
 
   /** Callback when the user changes the baseUrl in the dropdown. */
   onBaseUrlChange: (baseUrl: string) => void;

--- a/src/Api/RequestPathHeader.tsx
+++ b/src/Api/RequestPathHeader.tsx
@@ -16,21 +16,23 @@ export const RequestPathHeader = ({
   path: string;
 
   /** Array of baseUrls to select from. Dropdown is hidden when there are zero or one options. */
-  baseUrls: string[];
+  baseUrls: string[] | undefined;
 
   /** What value of baseUrl the dropdown should show as selected before the user has changed the selection. */
-  defaultBaseUrl?: string;
+  defaultBaseUrl?: string | undefined;
 
   /** Callback when the user changes the baseUrl in the dropdown. */
   onBaseUrlChange: (baseUrl: string) => void;
 }) => (
   <div className="text-sm md:text-base flex items-center space-x-2 mb-2">
     <RequestMethodBubble method={method} />
-    <BaseUrlDropdown
-      baseUrls={baseUrls}
-      defaultValue={defaultBaseUrl}
-      onChange={onBaseUrlChange}
-    />
+    {baseUrls && (
+      <BaseUrlDropdown
+        baseUrls={baseUrls}
+        defaultValue={defaultBaseUrl}
+        onChange={onBaseUrlChange}
+      />
+    )}
     <div className="font-mono text-[0.95rem] overflow-auto">
       <p className="inline-block text-slate-700 dark:text-slate-100 font-semibold">
         {path}

--- a/src/Api/index.ts
+++ b/src/Api/index.ts
@@ -1,11 +1,5 @@
 import { ApiPlayground } from "./ApiPlayground";
 import { RequestMethodBubble } from "./RequestMethodBubble";
 import { RequestPathHeader } from "./RequestPathHeader";
-import { BaseUrlDropdown } from "./BaseUrlDropdown";
 
-export {
-  ApiPlayground,
-  RequestMethodBubble,
-  RequestPathHeader,
-  BaseUrlDropdown,
-};
+export { ApiPlayground, RequestMethodBubble, RequestPathHeader };

--- a/src/Api/inputs/AddArrayItemButton.tsx
+++ b/src/Api/inputs/AddArrayItemButton.tsx
@@ -1,0 +1,21 @@
+export function AddArrayItemButton({ onClick }: { onClick: () => void }) {
+  // pointer-events-none on the plus sign SVG is needed to allow clicking the button underneath.
+  // Without it, you can't click on the button when hovering over the plus sign.
+  return (
+    <div className="relative">
+      <button
+        className="w-full py-0.5 px-2 rounded text-left border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 hover:border-slate-400 dark:hover:border-slate-500"
+        onClick={onClick}
+      >
+        Add Item
+      </button>
+      <svg
+        className="hidden sm:block absolute right-2 top-[7px] h-3 fill-slate-500 dark:fill-slate-400 pointer-events-none"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 448 512"
+      >
+        <path d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32V224H48c-17.7 0-32 14.3-32 32s14.3 32 32 32H192V432c0 17.7 14.3 32 32 32s32-14.3 32-32V288H400c17.7 0 32-14.3 32-32s-14.3-32-32-32H256V80z" />
+      </svg>
+    </div>
+  );
+}

--- a/src/Api/inputs/ApiInput.tsx
+++ b/src/Api/inputs/ApiInput.tsx
@@ -263,7 +263,7 @@ export function ApiInput({
         >
           {array.map((item, i) => (
             <ApiInput
-              key={item.param.name + i}
+              key={`${item.param.name}${i}`}
               param={item.param}
               value={item.value}
               onChangeParam={(

--- a/src/Api/inputs/ApiInput.tsx
+++ b/src/Api/inputs/ApiInput.tsx
@@ -1,36 +1,8 @@
 import clsx from "clsx";
 import { useState } from "react";
 import { ApiInputValue, Param } from "../types";
+import { AddArrayItemButton } from "./AddArrayItemButton";
 import { InputDropdown } from "./InputDropdown";
-
-const getArrayType = (type: string | undefined) => {
-  if (!type || type === "array") {
-    return "";
-  }
-  return type.replace(/\[\]/g, "");
-};
-
-function AddArrayItemButton({ onClick }: { onClick: () => void }) {
-  // pointer-events-none on the plus sign SVG is needed to allow clicking the button underneath.
-  // Without it, you can't click on the button when hovering over the plus sign.
-  return (
-    <div className="relative">
-      <button
-        className="w-full py-0.5 px-2 rounded text-left border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 hover:border-slate-400 dark:hover:border-slate-500"
-        onClick={onClick}
-      >
-        Add Item
-      </button>
-      <svg
-        className="hidden sm:block absolute right-2 top-[7px] h-3 fill-slate-500 dark:fill-slate-400 pointer-events-none"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 448 512"
-      >
-        <path d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32V224H48c-17.7 0-32 14.3-32 32s14.3 32 32 32H192V432c0 17.7 14.3 32 32 32s32-14.3 32-32V288H400c17.7 0 32-14.3 32-32s-14.3-32-32-32H256V80z" />
-      </svg>
-    </div>
-  );
-}
 
 export function ApiInput({
   param,
@@ -56,6 +28,7 @@ export function ApiInput({
   const [isExpandedProperties, setIsExpandedProperties] = useState(
     Boolean(param.required) || param.type === "array"
   );
+
   const [object, setObject] = useState<Record<string, any>>(
     param.type === "object" ? (value as any) : {}
   );
@@ -310,3 +283,10 @@ export function ApiInput({
     </div>
   );
 }
+
+const getArrayType = (type: string | undefined) => {
+  if (!type || type === "array") {
+    return "";
+  }
+  return type.replace(/\[\]/g, "");
+};

--- a/src/Api/inputs/ApiInput.tsx
+++ b/src/Api/inputs/ApiInput.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { useState } from "react";
-import { ApiInputValue, Param } from "./types";
+import { ApiInputValue, Param } from "../types";
+import { InputDropdown } from "./InputDropdown";
 
 const getArrayType = (type: string | undefined) => {
   if (!type || type === "array") {
@@ -10,6 +11,8 @@ const getArrayType = (type: string | undefined) => {
 };
 
 function AddArrayItemButton({ onClick }: { onClick: () => void }) {
+  // pointer-events-none on the plus sign SVG is needed to allow clicking the button underneath.
+  // Without it, you can't click on the button when hovering over the plus sign.
   return (
     <div className="relative">
       <button
@@ -19,7 +22,7 @@ function AddArrayItemButton({ onClick }: { onClick: () => void }) {
         Add Item
       </button>
       <svg
-        className="hidden sm:block absolute right-2 top-[7px] h-3 fill-slate-500 dark:fill-slate-400"
+        className="hidden sm:block absolute right-2 top-[7px] h-3 fill-slate-500 dark:fill-slate-400 pointer-events-none"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 448 512"
       >
@@ -62,7 +65,7 @@ export function ApiInput({
 
   let InputField;
 
-  // Todo: support multiple types
+  // TO DO: Support multiple types
   let lowerCaseParamType;
   if (typeof param.type === "string") {
     lowerCaseParamType = param.type?.toLowerCase();
@@ -117,28 +120,10 @@ export function ApiInput({
 
   if (lowerCaseParamType === "boolean") {
     InputField = (
-      <div className="relative">
-        <select
-          className="w-full py-0.5 px-2 rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 cursor-pointer"
-          onChange={(e) => {
-            const selection = e.target.value;
-            onInputChange(selection === "true");
-          }}
-        >
-          <option disabled selected>
-            Select
-          </option>
-          <option>true</option>
-          <option>false</option>
-        </select>
-        <svg
-          className="absolute right-2 top-[7px] h-3 fill-slate-600 dark:fill-slate-400"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 384 512"
-        >
-          <path d="M192 384c-8.188 0-16.38-3.125-22.62-9.375l-160-160c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L192 306.8l137.4-137.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-160 160C208.4 380.9 200.2 384 192 384z" />
-        </svg>
-      </div>
+      <InputDropdown
+        options={["true", "false"]}
+        onInputChange={(newValue: string) => onInputChange(newValue === "true")}
+      />
     );
   } else if (
     lowerCaseParamType === "integer" ||
@@ -167,7 +152,7 @@ export function ApiInput({
           }}
         />
         <svg
-          className="absolute right-2 top-[7px] h-3 fill-slate-500 dark:fill-slate-400 bg-border-slate-700"
+          className="absolute right-2 top-[7px] h-3 fill-slate-500 dark:fill-slate-400 bg-border-slate-700 pointer-events-none"
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 512 512"
         >
@@ -191,7 +176,7 @@ export function ApiInput({
         <span className="fill-slate-500 dark:fill-slate-400 group-hover:fill-slate-700 dark:group-hover:fill-slate-200">
           {isExpandedProperties ? (
             <svg
-              className="h-3 w-3"
+              className="h-3 w-3 pointer-events-none"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 512 512"
             >
@@ -199,7 +184,7 @@ export function ApiInput({
             </svg>
           ) : (
             <svg
-              className="h-3 w-3"
+              className="h-3 w-3 pointer-events-none"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 512 512"
             >
@@ -215,29 +200,7 @@ export function ApiInput({
     );
   } else if (param.enum) {
     InputField = (
-      <div className="relative">
-        <select
-          className="w-full py-0.5 px-2 rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 hover:border-slate-400 dark:hover:border-slate-500 cursor-pointer"
-          onChange={(e) => {
-            const selection = e.target.value;
-            onInputChange(selection);
-          }}
-        >
-          <option disabled selected>
-            Select
-          </option>
-          {param.enum.map((enumValue) => (
-            <option>{enumValue}</option>
-          ))}
-        </select>
-        <svg
-          className="absolute right-2 top-[7px] h-3 fill-slate-500 dark:fill-slate-400"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 384 512"
-        >
-          <path d="M192 384c-8.188 0-16.38-3.125-22.62-9.375l-160-160c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L192 306.8l137.4-137.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-160 160C208.4 380.9 200.2 384 192 384z" />
-        </svg>
-      </div>
+      <InputDropdown options={param.enum} onInputChange={onInputChange} />
     );
   } else {
     InputField = (

--- a/src/Api/inputs/ApiInput.tsx
+++ b/src/Api/inputs/ApiInput.tsx
@@ -110,7 +110,7 @@ export function ApiInput({
     InputField = (
       <button className="relative flex items-center px-2 w-full h-7 rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 border-dashed hover:bg-slate-50 dark:hover:bg-slate-800">
         <input
-          className="z-10 absolute inset-0 opacity-0 cursor-pointer"
+          className="z-5 absolute inset-0 opacity-0 cursor-pointer"
           type="file"
           onChange={(event) => {
             if (event.target.files == null) {
@@ -126,13 +126,11 @@ export function ApiInput({
         >
           <path d="M105.4 182.6c12.5 12.49 32.76 12.5 45.25 .001L224 109.3V352c0 17.67 14.33 32 32 32c17.67 0 32-14.33 32-32V109.3l73.38 73.38c12.49 12.49 32.75 12.49 45.25-.001c12.49-12.49 12.49-32.75 0-45.25l-128-128C272.4 3.125 264.2 0 256 0S239.6 3.125 233.4 9.375L105.4 137.4C92.88 149.9 92.88 170.1 105.4 182.6zM480 352h-160c0 35.35-28.65 64-64 64s-64-28.65-64-64H32c-17.67 0-32 14.33-32 32v96c0 17.67 14.33 32 32 32h448c17.67 0 32-14.33 32-32v-96C512 366.3 497.7 352 480 352zM432 456c-13.2 0-24-10.8-24-24c0-13.2 10.8-24 24-24s24 10.8 24 24C456 445.2 445.2 456 432 456z" />
         </svg>
-        {value != null && (value as any)[param.name] != null ? (
-          <span className="w-full truncate">
-            {(value as any)[param.name].name}
-          </span>
-        ) : (
-          "Choose file"
-        )}
+        <span className="w-full truncate text-left inline-block pointer-events-none">
+          {value != null && (value as any)[param.name] != null
+            ? (value as any)[param.name].name
+            : "Choose file"}
+        </span>
       </button>
     );
   } else if (isObject && !isArray) {

--- a/src/Api/inputs/InputDropdown.tsx
+++ b/src/Api/inputs/InputDropdown.tsx
@@ -1,20 +1,23 @@
 export const InputDropdown = ({
   options,
+  value,
   onInputChange,
 }: {
   options: string[];
+  value: string;
   onInputChange: (newValue: string) => void;
 }) => (
   <div className="relative">
     <select
       className="w-full py-0.5 px-2 rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 hover:border-slate-400 dark:hover:border-slate-500 cursor-pointer"
       onChange={(e) => onInputChange(e.target.value)}
+      // We use || instead of ?? because the default value passed to
+      // ApiPlayground is an empty string instead of undefined
+      value={value || "Select"}
     >
-      <option disabled selected>
-        Select
-      </option>
+      <option disabled>Select</option>
       {options.map((option) => (
-        <option>{option}</option>
+        <option key={option}>{option}</option>
       ))}
     </select>
     <DownArrowSvg />

--- a/src/Api/inputs/InputDropdown.tsx
+++ b/src/Api/inputs/InputDropdown.tsx
@@ -1,0 +1,32 @@
+export const InputDropdown = ({
+  options,
+  onInputChange,
+}: {
+  options: string[];
+  onInputChange: (newValue: string) => void;
+}) => (
+  <div className="relative">
+    <select
+      className="w-full py-0.5 px-2 rounded border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 hover:border-slate-400 dark:hover:border-slate-500 cursor-pointer"
+      onChange={(e) => onInputChange(e.target.value)}
+    >
+      <option disabled selected>
+        Select
+      </option>
+      {options.map((option) => (
+        <option>{option}</option>
+      ))}
+    </select>
+    <DownArrowSvg />
+  </div>
+);
+
+const DownArrowSvg = () => (
+  <svg
+    className="absolute right-2 top-[7px] h-3 fill-slate-500 dark:fill-slate-400 pointer-events-none"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 384 512"
+  >
+    <path d="M192 384c-8.188 0-16.38-3.125-22.62-9.375l-160-160c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L192 306.8l137.4-137.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-160 160C208.4 380.9 200.2 384 192 384z" />
+  </svg>
+);

--- a/src/css/globals.css
+++ b/src/css/globals.css
@@ -2,6 +2,13 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Disable browser's default styling on select tags */
+select {
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
 @layer components {
   .gray-frame {
     @apply bg-slate-800 rounded-xl shadow-lg dark:ring-1 dark:ring-white/10 dark:ring-inset relative;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { PillSelect } from "./PillSelect";
 import { Tab, Tabs } from "./Tabs";
 import { Tooltip } from "./Tooltip";
 import { Expandable } from "./Expandable";
-import { ApiPlayground } from "./Api";
+import { ApiPlayground, RequestMethodBubble, RequestPathHeader } from "./Api";
 
 // Import Tailwind
 import "./css/globals.css";
@@ -32,6 +32,8 @@ export {
   Note,
   Param,
   PillSelect,
+  RequestMethodBubble,
+  RequestPathHeader,
   Tabs,
   Tip,
   Tab,

--- a/src/stories/Api/ApiInput.stories.tsx
+++ b/src/stories/Api/ApiInput.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { ApiInput } from "../../Api/ApiInput";
+import { ApiInput } from "../../Api/inputs/ApiInput";
 import { ApiInputValue } from "../../Api/types";
 
 export default {
@@ -38,6 +38,25 @@ TextInputWithPlaceholder.args = {
   value: "",
 };
 
+export const BooleanInput = Template.bind({});
+BooleanInput.args = {
+  param: {
+    name: "Boolean Input",
+    type: "boolean",
+  },
+  value: true,
+};
+
+export const EnumInput = Template.bind({});
+EnumInput.args = {
+  param: {
+    name: "Enum Input",
+    type: "enum",
+    enum: ["Enum Option 1", "Enum Option 2", "Enum Option 3"],
+  },
+  value: "Enum Option 2",
+};
+
 export const ArrayInput = Template.bind({});
 ArrayInput.args = {
   param: {
@@ -64,4 +83,13 @@ ObjectInput.args = {
     "Example Property Name": 123,
     camelCasePropertyName: "Example string value",
   },
+};
+
+export const FileInput = Template.bind({});
+FileInput.args = {
+  param: {
+    name: "File Input",
+    type: "file",
+  },
+  value: "",
 };

--- a/src/stories/Api/ApiInput.stories.tsx
+++ b/src/stories/Api/ApiInput.stories.tsx
@@ -9,24 +9,27 @@ export default {
   component: ApiInput,
 } as ComponentMeta<typeof ApiInput>;
 
-const Template: ComponentStory<typeof ApiInput> = (args) => (
-  <div className="max-w-md">
-    <ApiInput
-      param={args.param}
-      value={args.value}
-      onChangeParam={(
-        parentInputs: string[],
-        paramName: string,
-        value: ApiInputValue
-      ) => {
-        console.log(value);
-      }}
-      // Storybook automatically adds a blank function if we don't do this, and our code
-      // shows a garbage can when the delete function exists.
-      onDeleteArrayItem={undefined}
-    />
-  </div>
-);
+const Template: ComponentStory<typeof ApiInput> = (args) => {
+  const [value, setValue] = React.useState<any>(args.value);
+  return (
+    <div className="max-w-md">
+      <ApiInput
+        param={args.param}
+        value={value}
+        onChangeParam={(
+          parentInputs: string[],
+          paramName: string,
+          value: ApiInputValue
+        ) => {
+          setValue(value);
+        }}
+        // Storybook automatically adds a blank function if we don't do this, and our code
+        // shows a garbage can when the delete function exists.
+        onDeleteArrayItem={undefined}
+      />
+    </div>
+  );
+};
 
 export const TextInputWithPlaceholder = Template.bind({});
 TextInputWithPlaceholder.args = {

--- a/src/stories/Api/ApiPlayground.stories.tsx
+++ b/src/stories/Api/ApiPlayground.stories.tsx
@@ -2,15 +2,23 @@ import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { ApiPlayground, RequestPathHeader } from "../../Api";
+import { ApiInputValue } from "../../Api/types";
 
 export default {
   title: "Api/ApiPlayground",
   component: ApiPlayground,
 } as ComponentMeta<typeof ApiPlayground>;
 
-const Template: ComponentStory<typeof ApiPlayground> = (args) => (
-  <ApiPlayground {...args} />
-);
+const Template: ComponentStory<typeof ApiPlayground> = (args) => {
+  const [paramValues, setParamValues] = React.useState<
+    Record<string, Record<string, any>>
+  >(args.paramValues);
+
+  args.paramValues = paramValues;
+  args.onChangeParamValues = setParamValues;
+
+  return <ApiPlayground {...args} />;
+};
 
 const testParamGroups = [
   {

--- a/src/stories/Api/ApiPlayground.stories.tsx
+++ b/src/stories/Api/ApiPlayground.stories.tsx
@@ -37,8 +37,8 @@ const testParamGroups = [
         name: "Object Input",
         type: "object",
         properties: [
-          { name: "Example Property Name" },
-          { name: "camelCasePropertyName" },
+          { name: "Example Property Name", type: "number" },
+          { name: "camelCasePropertyName", type: "string" },
         ],
       },
     ],

--- a/src/stories/Api/ApiPlayground.stories.tsx
+++ b/src/stories/Api/ApiPlayground.stories.tsx
@@ -12,6 +12,58 @@ const Template: ComponentStory<typeof ApiPlayground> = (args) => (
   <ApiPlayground {...args} />
 );
 
+const testParamGroups = [
+  {
+    name: "Body",
+    params: [
+      {
+        name: "Text Input",
+        type: "text",
+        placeholder: "Placeholder Value",
+      },
+      {
+        name: "Array Input",
+        type: "array",
+      },
+      {
+        name: "Object Input",
+        type: "object",
+        properties: [
+          { name: "Example Property Name" },
+          { name: "camelCasePropertyName" },
+        ],
+      },
+    ],
+  },
+  {
+    name: "Path",
+    params: [
+      {
+        name: "Text Input Second Page",
+        type: "text",
+        required: true,
+      },
+    ],
+  },
+];
+
+const testParamValues = {
+  Body: {
+    "Text Input": "",
+    "Array Input": [
+      { param: { name: "This text should be hidden", type: "text" }, value: 1 },
+      { param: { name: "This text should be hidden", type: "text" }, value: 2 },
+    ],
+    "Object Input": {
+      "Example Property Name": 123,
+      camelCasePropertyName: "Example string value",
+    },
+  },
+  Path: {
+    "Text Input Second Page": "",
+  },
+};
+
 export const HeaderButNoResponse = Template.bind({});
 HeaderButNoResponse.args = {
   method: "GET",
@@ -25,15 +77,15 @@ HeaderButNoResponse.args = {
       }}
     />
   ),
-  paramGroups: [],
-  paramValues: [],
+  paramGroups: testParamGroups,
+  paramValues: testParamValues,
   isSendingRequest: false,
 };
 
 export const NoHeader = Template.bind({});
 NoHeader.args = {
   method: "PATCH",
-  paramGroups: [],
-  paramValues: [],
+  paramGroups: testParamGroups,
+  paramValues: testParamValues,
   isSendingRequest: false,
 };

--- a/src/stories/Api/BaseUrlDropdown.stories.tsx
+++ b/src/stories/Api/BaseUrlDropdown.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { BaseUrlDropdown } from "../../Api";
+import { BaseUrlDropdown } from "../../Api/BaseUrlDropdown";
 
 export default {
   title: "Api/BaseUrlDropdown",


### PR DESCRIPTION
Adds stories for remaining playground input types and adds callback that lets parent of ApiPlayground store its state.

The callback is required to make the API Playground functional because it doesn't store its own state. The stories use `useState` to demo how a user could track the inputs.