### PR TITLE
Add support for default types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/components",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Open-source library of UI components made with React and TailwindCSS.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/components",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Open-source library of UI components made with React and TailwindCSS.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/Api/inputs/ApiInput.tsx
+++ b/src/Api/inputs/ApiInput.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ApiInputValue, Param } from "../types";
 import { AddArrayItemButton } from "./AddArrayItemButton";
 import { InputDropdown } from "./InputDropdown";
@@ -27,6 +27,15 @@ export function ApiInput({
   onDeleteArrayItem?: () => void;
   parentInputs?: string[];
 }) {
+  const onInputChange = (value: any) => {
+    onChangeParam(parentInputs, param.name, value);
+  };
+
+  useEffect(() => {
+    if (param.default) {
+      onInputChange(param.default);
+    }
+  }, [])
   const isObject = param.type === "object" && param.properties != null;
   const isArray = param.type === "array";
 
@@ -49,10 +58,6 @@ export function ApiInput({
   if (typeof param.type === "string") {
     lowerCaseParamType = param.type?.toLowerCase();
   }
-
-  const onInputChange = (value: any) => {
-    onChangeParam(parentInputs, param.name, value);
-  };
 
   const onObjectParentChange = (property: string, value: any) => {
     const newObj = { ...object, [property]: value };

--- a/src/Api/inputs/ApiInput.tsx
+++ b/src/Api/inputs/ApiInput.tsx
@@ -35,7 +35,8 @@ export function ApiInput({
     if (param.default) {
       onInputChange(param.default);
     }
-  }, [])
+  }, [param.default]);
+
   const isObject = param.type === "object" && param.properties != null;
   const isArray = param.type === "array";
 

--- a/src/Api/types.ts
+++ b/src/Api/types.ts
@@ -23,6 +23,7 @@ export type ParamGroup = {
 export type Param = {
   name: string;
   placeholder?: string;
+  default?: string;
   required?: boolean;
   type?: string;
   enum?: string[];

--- a/src/stories/Api/ApiInput.stories.tsx
+++ b/src/stories/Api/ApiInput.stories.tsx
@@ -42,6 +42,16 @@ TextInputWithPlaceholder.args = {
   value: "",
 };
 
+export const TextInputWithDefaultValue = Template.bind({});
+TextInputWithDefaultValue.args = {
+  param: {
+    name: "Text Input",
+    type: "text",
+    default: "Default Value",
+  },
+  value: "",
+};
+
 export const BooleanInput = Template.bind({});
 BooleanInput.args = {
   param: {


### PR DESCRIPTION
# Summary

This PR adds default value types for params

<img width="1512" alt="Screen Shot 2023-01-06 at 12 24 36 AM" src="https://user-images.githubusercontent.com/44352119/210960736-4d9ee4e4-76c9-4ddf-b2d5-77079220ccc6.png">

### Testing Plan

- Open Storybook locally
- Go to `ApiInput > Text Input with Default Value` and see that the default value loads automatically.
- Try changing the default value input field and see nothing changing
- No other params should be affected