### PR TITLE
Bump packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/components",
-  "version": "0.2.7",
+  "version": "0.2.10",
   "description": "Open-source library of UI components made with React and TailwindCSS.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
# Summary

There was a few publishes (0.2.8 and 0.2.9) that I used predominately to integrate test in the default branch. Not sure how to revert back so the simplest thing to avoid future errors is to just add to 2.10