### PR TITLE
Use Code Block color in Tooltip

### DIFF
--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -14,7 +14,7 @@ export function Tooltip({
   return (
     <span className="group z-10 inline relative">
       {underlineWhenTextOnly(children)}
-      <span className="hidden group-hover:flex w-fit lg:whitespace-nowrap absolute bottom-full left-1/2 mb-0.5 pb-1 -translate-x-1/2 bg-slate-800 text-center text-slate-50 text-xs px-1.5 py-1 rounded-lg border border-slate-50">
+      <span className="hidden group-hover:flex w-fit lg:whitespace-nowrap absolute bottom-full left-1/2 mb-0.5 pb-1 -translate-x-1/2 bg-codeblock text-center text-slate-50 text-xs px-1.5 py-1 rounded-lg border border-slate-50">
         {tip}
       </span>
     </span>
@@ -27,7 +27,7 @@ function underlineWhenTextOnly(children: ReactNode) {
   }
 
   return (
-    <span className="underline decoration-dotted decoration-2 underline-offset-4 decoration-slate-400 dark:decoration-slate-500">
+    <span className="underline decoration-dotted decoration-2 underline-offset-4 decoration-zinc-400 dark:decoration-zinc-500">
       {children}
     </span>
   );


### PR DESCRIPTION
Updates Tooltip colors for consistency with the rest of our designs.

Old:
<img width="400" alt="old" src="https://user-images.githubusercontent.com/110702161/214441984-3cf587b8-4fab-465a-9519-44b9a94b2583.png">

New:
<img width="400" alt="new" src="https://user-images.githubusercontent.com/110702161/214442002-229c537d-4118-488a-aca2-561c687bb702.png">
