### PR TITLE
Card+refs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "autoprefixer": "^10.4.8",
         "babel-loader": "^8.3.0",
         "chromatic": "^6.9.0",
+        "copyfiles": "^2.4.1",
         "css-loader": "^6.7.2",
         "cssnano": "^5.1.14",
         "glob-parent": "^6.0.2",
@@ -12650,6 +12651,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
+    "node_modules/copyfiles/node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/core-js": {
       "version": "3.25.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.0.tgz",
@@ -18458,6 +18487,40 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "dev": true
+    },
+    "node_modules/noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
+    "node_modules/noms/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
+    "node_modules/noms/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/noms/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -34817,6 +34880,29 @@
       "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true
     },
+    "copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "dependencies": {
+        "untildify": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+          "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+          "dev": true
+        }
+      }
+    },
     "core-js": {
       "version": "3.25.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.25.0.tgz",
@@ -39332,6 +39418,42 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
+    },
+    "noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+          "dev": true
+        }
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "build": "webpack",
     "prepare": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "build-mint-client": "npm run build && npm run copy-mint-client-node-modules",
+    "copy-mint-client-node-modules" : "copyfiles ./dist/**/* ../mint/client/node_modules/@mintlify/components/"
   },
   "author": "Mintlify",
   "bugs": {
@@ -29,6 +31,7 @@
     "react-dom": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
+    "copyfiles" : "^2.4.1",
     "@babel/core": "^7.20.5",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "build": "webpack",
     "prepare": "npm run build",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "build-mint-client": "npm run build && npm run copy-mint-client-node-modules",
-    "copy-mint-client-node-modules" : "copyfiles ./dist/**/* ../mint/client/node_modules/@mintlify/components/"
+    "build-storybook": "build-storybook"
   },
   "author": "Mintlify",
   "bugs": {
@@ -31,7 +29,6 @@
     "react-dom": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
-    "copyfiles" : "^2.4.1",
     "@babel/core": "^7.20.5",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -1,4 +1,4 @@
-import { ElementType, ComponentProps, Ref } from "react";
+import { ElementType, ComponentPropsWithoutRef, Ref } from "react";
 import clsx from "clsx";
 
 type ColorInterface = keyof typeof colors;
@@ -38,7 +38,7 @@ let colorsDark: Record<ColorInterface, string[]> = {
   ],
 };
 
-export interface ButtonPropsBase<T extends ElementType> {
+export interface ButtonPropsBase<T> {
   /**
    * Color of the button. Default is `gray`.
    */
@@ -59,6 +59,10 @@ export interface ButtonPropsBase<T extends ElementType> {
    * If provided, will render as an anchor element.
    */
   href?: string;
+  /**
+   * Ref of the element to be rendered.
+   */
+  mRef?: Ref<T>;
 }
 
 /**
@@ -66,15 +70,16 @@ export interface ButtonPropsBase<T extends ElementType> {
  * @typeParam T - Type of the Element rendered by the button.
  */
 export type ButtonProps<T extends ElementType> = ButtonPropsBase<T> &
-  Omit<ComponentProps<T>, keyof ButtonPropsBase<T>>;
+  Omit<ComponentPropsWithoutRef<T>, keyof ButtonPropsBase<T>>;
 
-function ButtonBase<T extends ElementType>({
+export function Button<T extends ElementType = "button">({
   as,
   color = "gray",
   darkColor = color,
   reverse = false,
   children,
   className,
+  mRef,
   ...props
 }: ButtonProps<T>) {
   let colorClasses = typeof color === "string" ? colors[color] : color;
@@ -97,6 +102,7 @@ function ButtonBase<T extends ElementType>({
         className
       )}
       {...props}
+      ref={mRef as Ref<any>}
     >
       {children}
       <svg
@@ -119,11 +125,4 @@ function ButtonBase<T extends ElementType>({
       </svg>
     </Component>
   );
-}
-
-export function Button <T extends ElementType = "button">({
-  ref,
-  ...rest
-}: ButtonProps<T> & { ref: Ref<T> }) {
-  return <ButtonBase {...rest} ref={ref} />;
 }

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -1,4 +1,10 @@
-import { ElementType, ComponentPropsWithoutRef } from "react";
+import {
+  ElementType,
+  ComponentPropsWithoutRef,
+  forwardRef,
+  ForwardedRef,
+  ComponentProps,
+} from "react";
 import clsx from "clsx";
 
 type ColorInterface = keyof typeof colors;
@@ -71,8 +77,9 @@ export function Button<T extends ElementType = "button">({
   darkColor = color,
   reverse = false,
   children,
+  className,
   ...props
-}: ButtonProps<T> & Omit<ComponentPropsWithoutRef<T>, keyof ButtonProps<T>>) {
+}: ButtonProps<T> & Omit<ComponentProps<T>, keyof ButtonProps<T>>) {
   let colorClasses = typeof color === "string" ? colors[color] : color;
   let darkColorClasses =
     typeof darkColor === "string" ? colorsDark[darkColor] || [] : darkColor;
@@ -88,7 +95,8 @@ export function Button<T extends ElementType = "button">({
         "group inline-flex items-center h-9 rounded-full text-sm font-semibold whitespace-nowrap px-3 focus:outline-none focus:ring-2",
         colorClasses[0],
         darkColorClasses[0],
-        reverse && "flex-row-reverse"
+        reverse && "flex-row-reverse",
+        className
       )}
       {...props}
     >

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -1,10 +1,4 @@
-import {
-  ElementType,
-  ComponentPropsWithoutRef,
-  forwardRef,
-  ForwardedRef,
-  ComponentProps,
-} from "react";
+import { ElementType, ComponentProps, Ref } from "react";
 import clsx from "clsx";
 
 type ColorInterface = keyof typeof colors;
@@ -44,11 +38,7 @@ let colorsDark: Record<ColorInterface, string[]> = {
   ],
 };
 
-/**
- * Props for the `Button` component
- * @typeParam T - Type of the Element rendered by the button.
- */
-interface ButtonProps<T extends ElementType> {
+export interface ButtonPropsBase<T extends ElementType> {
   /**
    * Color of the button. Default is `gray`.
    */
@@ -71,7 +61,14 @@ interface ButtonProps<T extends ElementType> {
   href?: string;
 }
 
-export function Button<T extends ElementType = "button">({
+/**
+ * Props for the `Button` component
+ * @typeParam T - Type of the Element rendered by the button.
+ */
+export type ButtonProps<T extends ElementType> = ButtonPropsBase<T> &
+  Omit<ComponentProps<T>, keyof ButtonPropsBase<T>>;
+
+function ButtonBase<T extends ElementType>({
   as,
   color = "gray",
   darkColor = color,
@@ -79,7 +76,7 @@ export function Button<T extends ElementType = "button">({
   children,
   className,
   ...props
-}: ButtonProps<T> & Omit<ComponentProps<T>, keyof ButtonProps<T>>) {
+}: ButtonProps<T>) {
   let colorClasses = typeof color === "string" ? colors[color] : color;
   let darkColorClasses =
     typeof darkColor === "string" ? colorsDark[darkColor] || [] : darkColor;
@@ -89,6 +86,7 @@ export function Button<T extends ElementType = "button">({
    * Defaults to `button`.
    */
   const Component = as || props.href != undefined ? "a" : "button";
+
   return (
     <Component
       className={clsx(
@@ -121,4 +119,11 @@ export function Button<T extends ElementType = "button">({
       </svg>
     </Component>
   );
+}
+
+export function Button <T extends ElementType = "button">({
+  ref,
+  ...rest
+}: ButtonProps<T> & { ref: Ref<T> }) {
+  return <ButtonBase {...rest} ref={ref} />;
 }

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -1,14 +1,8 @@
-import {
-  ComponentProps,
-  ElementType,
-  ForwardedRef,
-  ReactNode,
-  Ref,
-} from "react";
+import { ComponentPropsWithoutRef, ElementType, ReactNode, Ref } from "react";
 import clsx from "clsx";
 import isAbsoluteUrl from "is-absolute-url";
 
-export interface CardPropsBase<T extends ElementType> {
+export interface CardPropsBase<T> {
   /**
    * Large title above children.
    */
@@ -28,7 +22,7 @@ export interface CardPropsBase<T extends ElementType> {
   /**
    * Ref of the element to be rendered.
    */
-  mRef?: ForwardedRef<T>;
+  mRef?: Ref<T>;
 }
 
 /**
@@ -36,14 +30,15 @@ export interface CardPropsBase<T extends ElementType> {
  * @typeParam T - Type of the Element rendered by the card.
  */
 export type CardProps<T extends ElementType> = CardPropsBase<T> &
-  Omit<ComponentProps<T>, keyof CardPropsBase<T>>;
+  Omit<ComponentPropsWithoutRef<T>, keyof CardPropsBase<T>>;
 
-function CardBase<T extends ElementType>({
+export function Card<T extends ElementType = "div">({
   title,
   icon,
   className,
   children,
   as,
+  mRef,
   ...props
 }: CardProps<T>) {
   /**
@@ -66,6 +61,7 @@ function CardBase<T extends ElementType>({
       )}
       {...newTabProps}
       {...props}
+      ref={mRef as Ref<any>}
     >
       {icon ? (
         <div className="h-6 w-6 fill-slate-800 dark:fill-slate-100 text-slate-800 dark:text-slate-100">
@@ -92,11 +88,4 @@ function CardBase<T extends ElementType>({
       </span>
     </Component>
   );
-}
-
-export function Card<T extends ElementType = "div">({
-  ref,
-  ...rest
-}: CardProps<T> & { ref: Ref<T> }) {
-  return <CardBase {...rest} ref={ref} />;
 }

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -1,50 +1,64 @@
-import { ReactNode } from "react";
+import {
+  ComponentProps,
+  ElementType,
+  ForwardedRef,
+  forwardRef,
+  ReactNode,
+} from "react";
 import clsx from "clsx";
 import isAbsoluteUrl from "is-absolute-url";
 
-export function Card({
+/**
+ * Props for the `Card` component
+ * @typeParam T - Type of the Element rendered by the card.
+ */
+interface CardProps<T extends ElementType> {
+  /**
+   * Large title above children.
+   */
+  title?: string;
+  /**
+   * Icon to the top-left of the title.
+   */
+  icon?: ReactNode;
+  /**
+   * Type of element to be rendered.
+   */
+  as?: T;
+  /**
+   * If provided, will render as an anchor element.
+   */
+  href?: string;
+}
+
+export function Card<T extends ElementType = "div">({
   title,
   icon,
   className,
-  href,
-  onClick,
   children,
-}: {
-  /** Large title above children */
-  title?: string;
+  as,
+  ...props
+}: CardProps<T> & Omit<ComponentProps<T>, keyof CardProps<T>>) {
+  /**
+   * If provided, use `as` or an `a` tag if linking to things with href.
+   * Defaults to `div`.
+   */
+  const Component = as || props.href != undefined ? "a" : "div";
 
-  /** Icon to the top-left of the title */
-  icon?: ReactNode;
-
-  /** Additional classes */
-  className?: string;
-
-  /** Link to make the entire card clickable */
-  href?: string;
-
-  /** Function to trigger when the card is clicked */
-  onClick?: any;
-
-  children?: ReactNode;
-}) {
-  // Use an <a> tag if we are linking to things
-  const Tag = href ? "a" : "div";
-
-  const openLinksInNewTab = isAbsoluteUrl(href ?? "");
+  const openLinksInNewTab = isAbsoluteUrl(props.href ?? "");
   const newTabProps = openLinksInNewTab
     ? { target: "_blank", rel: "noreferrer" }
     : {};
 
   return (
-    <Tag
+    <Component
       className={clsx(
         "block not-prose font-normal group relative my-2 ring-2 ring-transparent rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden px-6 py-5 w-full",
-        href && "cursor-pointer",
+        props.href && "cursor-pointer",
         className
       )}
-      href={href}
-      onClick={onClick}
       {...newTabProps}
+      {...props}
     >
       {icon ? (
         <div className="h-6 w-6 fill-slate-800 dark:fill-slate-100 text-slate-800 dark:text-slate-100">
@@ -69,6 +83,6 @@ export function Card({
       >
         {children}
       </span>
-    </Tag>
+    </Component>
   );
 }

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -2,17 +2,13 @@ import {
   ComponentProps,
   ElementType,
   ForwardedRef,
-  forwardRef,
   ReactNode,
+  Ref,
 } from "react";
 import clsx from "clsx";
 import isAbsoluteUrl from "is-absolute-url";
 
-/**
- * Props for the `Card` component
- * @typeParam T - Type of the Element rendered by the card.
- */
-interface CardProps<T extends ElementType> {
+export interface CardPropsBase<T extends ElementType> {
   /**
    * Large title above children.
    */
@@ -29,16 +25,27 @@ interface CardProps<T extends ElementType> {
    * If provided, will render as an anchor element.
    */
   href?: string;
+  /**
+   * Ref of the element to be rendered.
+   */
+  mRef?: ForwardedRef<T>;
 }
 
-export function Card<T extends ElementType = "div">({
+/**
+ * Props for the `Card` component
+ * @typeParam T - Type of the Element rendered by the card.
+ */
+export type CardProps<T extends ElementType> = CardPropsBase<T> &
+  Omit<ComponentProps<T>, keyof CardPropsBase<T>>;
+
+function CardBase<T extends ElementType>({
   title,
   icon,
   className,
   children,
   as,
   ...props
-}: CardProps<T> & Omit<ComponentProps<T>, keyof CardProps<T>>) {
+}: CardProps<T>) {
   /**
    * If provided, use `as` or an `a` tag if linking to things with href.
    * Defaults to `div`.
@@ -85,4 +92,11 @@ export function Card<T extends ElementType = "div">({
       </span>
     </Component>
   );
+}
+
+export function Card<T extends ElementType = "div">({
+  ref,
+  ...rest
+}: CardProps<T> & { ref: Ref<T> }) {
+  return <CardBase {...rest} ref={ref} />;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { Accordion, AccordionGroup } from "./Accordion";
 import { AppearFromTop } from "./AppearFromTop";
 import { ApiPlayground, RequestMethodBubble, RequestPathHeader } from "./Api";
-import { Button } from "./Button";
-import { Card } from "./Card";
+import { Button, ButtonProps, ButtonPropsBase } from "./Button";
+import { Card, CardProps, CardPropsBase } from "./Card";
 import { CardGroup } from "./CardGroup";
 import { CodeBlock, CodeGroup } from "./Code";
 import { Info, Warning, Note, Tip, Check } from "./Callouts";
@@ -15,6 +15,8 @@ import { Expandable } from "./Expandable";
 
 // Import Tailwind
 import "./css/globals.css";
+
+export type { CardProps, ButtonProps, ButtonPropsBase, CardPropsBase };
 
 export {
   Accordion,

--- a/src/stories/Display/Cards/Card.stories.tsx
+++ b/src/stories/Display/Cards/Card.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Card } from "../../../Card";
+import { Card, CardProps } from "../../../Card";
 import { forwardRef, useRef } from "react";
 
 export default {
@@ -11,7 +11,8 @@ export default {
 } as ComponentMeta<typeof Card>;
 
 const Template: ComponentStory<typeof Card> = (args) => <Card {...args} />;
-const defaultText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae porta arcu. Nam nec congue tellus. Nunc eleifend fermentum tortor, nec consectetur libero molestie eget. Nulla rhoncus elit eu mi auctor fringilla. Quisque et mattis eros, eu hendrerit libero. Mauris in erat ex. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Pellentesque velit nisi, ornare at tincidunt ac, euismod sit amet ligula. In sodales ligula quis vestibulum lacinia. Pellentesque ut elit lectus. Sed tristique nunc nulla, non ultricies turpis eleifend non. Quisque viverra mauris vel sapien dictum, et elementum ante accumsan."
+const defaultText =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae porta arcu. Nam nec congue tellus. Nunc eleifend fermentum tortor, nec consectetur libero molestie eget. Nulla rhoncus elit eu mi auctor fringilla. Quisque et mattis eros, eu hendrerit libero. Mauris in erat ex. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Pellentesque velit nisi, ornare at tincidunt ac, euismod sit amet ligula. In sodales ligula quis vestibulum lacinia. Pellentesque ut elit lectus. Sed tristique nunc nulla, non ultricies turpis eleifend non. Quisque viverra mauris vel sapien dictum, et elementum ante accumsan.";
 
 export const Default = Template.bind({});
 Default.args = {
@@ -19,20 +20,11 @@ Default.args = {
   children: defaultText,
 };
 
-export const WithCustomClasses = Template.bind({});
-WithCustomClasses.args = {
-  title: "Card Title",
-  children: "Card text.",
-  href: "https://google.com",
-  className:
-    "bg-red-100 border-red-200 hover:border-red-800 dark:border-red-600 dark:hover:border-red-400",
-};
-
-const icon =  (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-    </svg>
-)
+const icon = (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+  </svg>
+);
 
 export const WithCustomIcon = Template.bind({});
 WithCustomIcon.args = {
@@ -47,4 +39,28 @@ NoTitle.args = {
   children: "The card text should be darker if there is no title.",
 };
 
+const RefCard = forwardRef<"div", CardProps<"div">>((args, ref) => (
+  <Card {...args} mRef={ref} />
+));
+RefCard.displayName = "RefCard";
+const RefTemplate: ComponentStory<typeof RefCard> = (args) => {
+  const ref = useRef<"div">();
+  return (
+    <RefCard
+      {...args}
+      ref={ref}
+      onClick={(e) => {
+        args.onClick?.(e);
+        console.log(ref.current);
+      }}
+    />
+  );
+};
 
+export const WithCustomClassesAndRef = RefTemplate.bind({});
+WithCustomClassesAndRef.args = {
+  title: "Card Title",
+  children: "Card text.",
+  className:
+    "bg-red-100 border-red-200 hover:border-red-800 dark:border-red-600 dark:hover:border-red-400",
+};

--- a/src/stories/Display/Cards/Card.stories.tsx
+++ b/src/stories/Display/Cards/Card.stories.tsx
@@ -11,11 +11,12 @@ export default {
 } as ComponentMeta<typeof Card>;
 
 const Template: ComponentStory<typeof Card> = (args) => <Card {...args} />;
+const defaultText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vitae porta arcu. Nam nec congue tellus. Nunc eleifend fermentum tortor, nec consectetur libero molestie eget. Nulla rhoncus elit eu mi auctor fringilla. Quisque et mattis eros, eu hendrerit libero. Mauris in erat ex. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Pellentesque velit nisi, ornare at tincidunt ac, euismod sit amet ligula. In sodales ligula quis vestibulum lacinia. Pellentesque ut elit lectus. Sed tristique nunc nulla, non ultricies turpis eleifend non. Quisque viverra mauris vel sapien dictum, et elementum ante accumsan."
 
 export const Default = Template.bind({});
 Default.args = {
-  title: "Card Title",
-  children: "Card text.",
+  title: defaultText.substring(0, 26),
+  children: defaultText,
 };
 
 export const WithCustomClasses = Template.bind({});
@@ -27,25 +28,23 @@ WithCustomClasses.args = {
     "bg-red-100 border-red-200 hover:border-red-800 dark:border-red-600 dark:hover:border-red-400",
 };
 
-export const WithCustomIcon = Template.bind({});
-WithCustomIcon.args = {
-  title: "Card Title",
-  icon: (
+const icon =  (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
       <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
     </svg>
-  ),
-  iconColor: "#ff0000",
+)
+
+export const WithCustomIcon = Template.bind({});
+WithCustomIcon.args = {
+  title: "Card Title",
+  icon,
   children: "Card text.",
 };
 
 export const NoTitle = Template.bind({});
 NoTitle.args = {
-  icon: (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-    </svg>
-  ),
-  iconColor: "#ff0000",
+  icon,
   children: "The card text should be darker if there is no title.",
 };
+
+

--- a/src/stories/Display/Cards/Card.stories.tsx
+++ b/src/stories/Display/Cards/Card.stories.tsx
@@ -2,13 +2,21 @@ import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { Card } from "../../../Card";
+import { forwardRef, useRef } from "react";
 
 export default {
   title: "Display/Cards/Card",
   component: Card,
+  argTypes: { onClick: { action: "clicked" } },
 } as ComponentMeta<typeof Card>;
 
 const Template: ComponentStory<typeof Card> = (args) => <Card {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  title: "Card Title",
+  children: "Card text.",
+};
 
 export const WithCustomClasses = Template.bind({});
 WithCustomClasses.args = {

--- a/src/stories/Interactive/Button.stories.tsx
+++ b/src/stories/Interactive/Button.stories.tsx
@@ -6,7 +6,7 @@ import { Button } from "../../Button";
 export default {
   title: "Interactive/Button",
   component: Button,
-  argTypes: { onClick: { action: 'clicked' } },
+  argTypes: { onClick: { action: "clicked" } },
 } as ComponentMeta<typeof Button>;
 
 const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
@@ -23,3 +23,12 @@ Indigo.args = {
   color: "indigo",
 };
 
+export const WithCustomClasses = Template.bind({});
+WithCustomClasses.args = {
+  title: "Card Title",
+  children: "Button Text",
+  href: "https://mintlify.com",
+  color: "pink",
+  className:
+    "bg-red-100 hover:bg-red-200 border-red-200 hover:border-red-800 dark:border-red-600 dark:hover:border-red-400",
+};

--- a/src/stories/Interactive/Button.stories.tsx
+++ b/src/stories/Interactive/Button.stories.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import { Button } from "../../Button";
+import { forwardRef, useRef } from "react";
+import { Card, CardProps } from "../../Card";
 
 export default {
   title: "Interactive/Button",
@@ -13,7 +15,7 @@ const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
-  children: "Button Text",
+  children: "Lorem ipsum",
 };
 
 export const Indigo = Template.bind({});
@@ -23,12 +25,29 @@ Indigo.args = {
   color: "indigo",
 };
 
-export const WithCustomClasses = Template.bind({});
-WithCustomClasses.args = {
+const RefButton = forwardRef<"button", CardProps<"button">>((args, ref) => (
+  <Card {...args} mRef={ref} />
+));
+RefButton.displayName = "RefButton";
+const RefTemplate: ComponentStory<typeof RefButton> = (args) => {
+  const ref = useRef<"button">();
+  return (
+    <RefButton
+      {...args}
+      ref={ref}
+      onClick={(e) => {
+        args.onClick?.(e);
+        console.log(ref.current);
+      }}
+    />
+  );
+};
+
+export const WithCustomClassesAndRef = RefTemplate.bind({});
+WithCustomClassesAndRef.args = {
   title: "Card Title",
   children: "Button Text",
-  href: "https://mintlify.com",
-  color: "pink",
   className:
-    "bg-red-100 hover:bg-red-200 border-red-200 hover:border-red-800 dark:border-red-600 dark:hover:border-red-400",
+    "bg-purple-100 text-purple-600 hover:bg-purple-200 hover:text-purple-700 focus:ring-purple-500 " +
+    "text-purple-500 group-hover:text-purple-600",
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,13 @@
     "jsx": "react-jsx",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
   },
-  "include": ["src"],
-  "exclude": ["node_modules", "src/stories"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "src/stories"
+  ]
 }


### PR DESCRIPTION
### Changes

- Improves Card similarly to the Button, but should not change behaviour.
- Changes component prop type of button and card to allow refs with 'mRef' prop to reduce warnings/errors. This is mainly because forwardRef does not work well with generics and most workarounds are really hacky.
But it allows for something like this to get refs or to just remove warnings:
```tsx
const RefButton = forwardRef<"button", CardProps<"button">>((args, ref) => (
  <Card {...args} mRef={ref} />
));
RefButton.displayName = "RefButton";
```
```tsx
  const ref = useRef<"button">();
  return (
    <RefButton
      {...args}
      ref={ref}
      onClick={(e) => {
        args.onClick?.(e);
        console.log(ref.current);
      }}
    />
  );
```
- Allow button to have additional classNames.
- Adds stories to test className and refs
- Adds `copyfiles` and npm scripts for copying dist to `../mint/client/node_modules/@mintlify/components/`.
This was just for testing purposes and there is probably a better alternative in the future.
Could also use a local npm repo or a published beta/alpha version.

### Tests/Stories


I tested locally with Storybook and with the mint repo and client and a new starter template.
In Storybook everything is behaving as expected as far as I am aware.
In the client changing the client Card to something like:
```tsx
  const RefCard = forwardRef<'a', CardProps<'a'>>((args, ref) => (
    <GenericCard {...args} mRef={ref} />
  ));
  RefCard.displayName = 'RefCard';

  // We don't use DynamicLink because we cannot wrap the Card in an extra <a> tag without
  // messing with the Card's styling. The Card already sets an <a> tag when href is passed to it.
  if (href && (href.startsWith('/') || href.startsWith('#'))) {
    return (
      <Link href={href} passHref legacyBehavior>
        <RefCard {...props} />
      </Link>
    );
  }
```
resolves the warning while keeping the ref but it introduced another warning:
`React does not recognize the mRef prop on a DOM element.`
This might just be because of local copying into `node_modules` and `dev` since typescript navigates to the .dts files fine and it seems to work but it might be better to test with a properly built and published package.

I created this as a draft for now because it might be neccessary to  bump the version and test it with a local package.



