### PR TITLE
fix text of clipboard button and pop-in

### DIFF
--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -28,11 +28,6 @@ export function CodeBlock({
 
   children?: any;
 }) {
-  const [hydrated, setHydrated] = useState(false);
-
-  useEffect(() => {
-    setHydrated(true);
-  }, []);
 
   const Button = () => (
     <CopyToClipboardButton
@@ -46,10 +41,10 @@ export function CodeBlock({
     <div className={clsx("mt-5 mb-8 not-prose gray-frame", filename && "pt-2")}>
       {filename ? (
         <CodeTabBar filename={filename} filenameColor={filenameColor}>
-          {hydrated ? <Button /> : undefined}
+          <Button />
         </CodeTabBar>
       ) : null}
-      {!filename && hydrated && (
+      {!filename && (
         <div className="z-10 absolute top-5 right-5">
           <Button />
         </div>
@@ -58,7 +53,7 @@ export function CodeBlock({
         className="code-in-gray-frame children:!my-0 children:!shadow-none children:!bg-transparent"
         style={{ fontVariantLigatures: "none" }}
       >
-        {hydrated ? children : null}
+        {children}
       </div>
     </div>
   );

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -6,11 +6,17 @@ import { CopyToClipboardButton } from "./CopyToClipboardButton";
 
 export type CodeGroupProps = {
   children: any;
-
-  /** Color of the filename text and the border underneath it when the content is being shown */
+  /**
+   * Color of the filename text and the border underneath it when the content is being shown
+   */
   selectedColor?: string;
-
-  /** Background color for the tooltip saying Copied when you click the clipboard */
+  /**
+   * Background color for the tooltip saying `Click to Copy` when hovering the clipboard button.
+   */
+  tooltipColor?: string;
+  /**
+   * Background color for the tooltip saying `Copied` when clicking the clipboard button.
+   */
   copiedTooltipColor?: string;
 
   isSmallText?: boolean;
@@ -26,6 +32,7 @@ export type CodeGroupProps = {
 export function CodeGroup({
   children,
   selectedColor,
+  tooltipColor,
   copiedTooltipColor,
   isSmallText,
 }: CodeGroupProps) {
@@ -81,7 +88,8 @@ export function CodeGroup({
           {hydrated && selectedChild?.props ? (
             <CopyToClipboardButton
               textToCopy={getNodeText(selectedChild?.props?.children)}
-              tooltipColor={copiedTooltipColor ?? selectedColor}
+              tooltipColor={tooltipColor ?? selectedColor}
+              copiedTooltipColor={copiedTooltipColor ?? tooltipColor ?? selectedColor}
             />
           ) : undefined}
         </div>

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -19,7 +19,7 @@ export function CopyToClipboardButton({
   }
 
   // Hide copy button if the browser does not support it
-  if (!navigator.clipboard) {
+  if (typeof window !== 'undefined' && !navigator?.clipboard) {
     console.warn(
       "The browser's Clipboard API is unavailable. The Clipboard API is only available on HTTPS."
     );
@@ -28,6 +28,7 @@ export function CopyToClipboardButton({
 
   return (
     <button
+      aria-label={'Copy code to clipboard'}
       className="relative group"
       onClick={async () => {
         const result = await copyToClipboard(textToCopy);
@@ -50,7 +51,7 @@ export function CopyToClipboardButton({
         color={hidden ? tooltipColor : copiedTooltipColor}
         className={`${hidden ? "invisible" : undefined} group-hover:visible`}
       >
-        {hidden ? "Click to Copy" : "Copied"}
+        {hidden ? "Copy" : "Copied"}
       </Tooltip>
     </button>
   );
@@ -72,20 +73,18 @@ function Tooltip({
       )}
     >
       <div
-        className="relative whitespace-nowrap text-white text-xs leading-6 font-medium px-1.5 rounded-lg"
+        className={`relative whitespace-nowrap text-white text-xs leading-6 font-medium px-1.5 rounded-lg`}
         style={{ background: color }}
         data-reach-alert="true"
       >
         {children}
         <div
+          className={`absolute border-solid`}
           style={{
-            content: "",
-            position: "absolute",
             top: "100%",
             left: "50%",
             marginLeft: "-6px",
             borderWidth: "6px",
-            borderStyle: "solid",
             borderColor: `${color} transparent transparent transparent`,
           }}
         />


### PR DESCRIPTION
### Changes

- fixes pop-in of CodeBlocks.
- fixes clipboard button text, which causes it to be cut off and have a scroll bar at the bottom. If we want to display more text here we could move the tooltip to the left and move the arrow to the right but not sure if that's worth it.
![214987447-65272a8b-748c-44a6-bc2a-a657dd8726ca](https://user-images.githubusercontent.com/34443492/214987982-070131b8-7c74-4199-87bd-6c473a2108e0.png)
![image](https://user-images.githubusercontent.com/34443492/214988048-c3f6bc5b-402e-48a6-b0d2-263aa3d2c522.png)
![image](https://user-images.githubusercontent.com/34443492/214987417-5210dcc0-bf88-4b15-b843-324e22d52b72.png)

### Tests

Tested locally with the mit client and a starter template.
There is one warning from the CodeBlock component that remains:
`Extra attributes from the server: tabindex`