### PR TITLE
Pop in testing && improvements

### DIFF
--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -1,16 +1,10 @@
 import clsx from "clsx";
 import { getNodeText } from "../utils/getNodeText";
-import { ReactElement } from "react";
+import { ComponentPropsWithoutRef, ReactElement } from "react";
 
 import { CopyToClipboardButton } from "./CopyToClipboardButton";
 
-export function CodeBlock({
-  filename,
-  filenameColor,
-  tooltipColor,
-  copiedTooltipColor,
-  children,
-}: {
+export interface CodeBlockPropsBase {
   filename?: string;
   /**
    *  Color of the filename text and the border underneath it when content is being shown.
@@ -24,10 +18,20 @@ export function CodeBlock({
    * Background color for the tooltip saying `Copied` when clicking the clipboard button.
    */
   copiedTooltipColor?: string;
+}
 
-  children?: any;
-}) {
+export type CodeBlockProps = CodeBlockPropsBase &
+  Omit<ComponentPropsWithoutRef<"div">, keyof CodeBlockPropsBase>;
 
+export function CodeBlock({
+  filename,
+  filenameColor,
+  tooltipColor,
+  copiedTooltipColor,
+  children,
+  className,
+  ...props
+}: CodeBlockProps) {
   const Button = () => (
     <CopyToClipboardButton
       textToCopy={getNodeText(children)}
@@ -37,7 +41,14 @@ export function CodeBlock({
   );
 
   return (
-    <div className={clsx("mt-5 mb-8 not-prose gray-frame", filename && "pt-2")}>
+    <div
+      className={clsx(
+        "mt-5 mb-8 not-prose gray-frame",
+        filename && "pt-2",
+        className
+      )}
+      {...props}
+    >
       {filename ? (
         <CodeTabBar filename={filename} filenameColor={filenameColor}>
           <Button />

--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -1,5 +1,4 @@
 import clsx from "clsx";
-import { useEffect, useState } from "react";
 import { getNodeText } from "../utils/getNodeText";
 import { ReactElement } from "react";
 

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -1,6 +1,5 @@
 import { Tab } from "@headlessui/react";
 import clsx from "clsx";
-import { useEffect, useState } from "react";
 import { getNodeText } from "../utils/getNodeText";
 import { CopyToClipboardButton } from "./CopyToClipboardButton";
 
@@ -27,7 +26,7 @@ export type CodeGroupProps = {
  * Uses CodeBlocks as children but does not render them directly. Instead,
  * CodeGroup extracts the props and renders CodeBlock's children.
  *
- * @param {CodeBlock[]} props.children
+ * @param CodeBlock[] children
  */
 export function CodeGroup({
   children,
@@ -36,13 +35,6 @@ export function CodeGroup({
   copiedTooltipColor,
   isSmallText,
 }: CodeGroupProps) {
-  const [selectedIndex, setSelectedIndex] = useState<number>(0);
-  const [hydrated, setHydrated] = useState(false);
-
-  useEffect(() => {
-    setHydrated(true);
-  }, []);
-
   if (children == null) {
     // Hide the frame when no children were passed
     console.warn(
@@ -56,19 +48,13 @@ export function CodeGroup({
     return null;
   }
 
-  const selectedChild = children.filter(
-    (_: any, i: number) => i === selectedIndex
-  )[0];
-
   return (
     <Tab.Group
       as="div"
-      onChange={setSelectedIndex as any}
       className="not-prose gray-frame"
     >
-      <div className="flex text-xs leading-6 rounded-tl-xl pt-2">
-        <Tab.List className="flex">
-          {children.map((child: any, tabIndex: number) => (
+      <Tab.List className="flex text-xs leading-6 rounded-tl-xl pt-2">
+        {({ selectedIndex }) => <>{( children.map((child: any, tabIndex: number) => (
             <TabItem
               key={child?.props?.filename + "TabItem" + tabIndex}
               myIndex={tabIndex}
@@ -77,23 +63,24 @@ export function CodeGroup({
             >
               {child?.props?.filename || "Filename"}
             </TabItem>
-          ))}
+          )))}
+          <div
+              className={clsx(
+                  "flex-auto flex justify-end bg-codeblock-tabs border-y border-slate-500/30 pr-4 rounded-tr",
+                  selectedIndex === children.length - 1 ? "rounded-tl border-l" : ""
+              )}
+          >
+            {children[selectedIndex] ? (
+                <CopyToClipboardButton
+                    textToCopy={getNodeText(children[selectedIndex]?.props?.children)}
+                    tooltipColor={tooltipColor ?? selectedColor}
+                    copiedTooltipColor={copiedTooltipColor ?? tooltipColor ?? selectedColor}
+                />
+            ) : undefined}
+          </div>
+        </>
+          }
         </Tab.List>
-        <div
-          className={clsx(
-            "flex-auto flex justify-end bg-codeblock-tabs border-y border-slate-500/30 pr-4 rounded-tr",
-            selectedIndex === children.length - 1 ? "rounded-tl border-l" : ""
-          )}
-        >
-          {hydrated && selectedChild?.props ? (
-            <CopyToClipboardButton
-              textToCopy={getNodeText(selectedChild?.props?.children)}
-              tooltipColor={tooltipColor ?? selectedColor}
-              copiedTooltipColor={copiedTooltipColor ?? tooltipColor ?? selectedColor}
-            />
-          ) : undefined}
-        </div>
-      </div>
       <Tab.Panels className="flex overflow-auto">
         {children.map((child: any) => (
           <Tab.Panel
@@ -104,7 +91,7 @@ export function CodeGroup({
             )}
             style={{ fontVariantLigatures: "none" }}
           >
-            {hydrated && child?.props?.children}
+            {child?.props?.children}
           </Tab.Panel>
         ))}
       </Tab.Panels>
@@ -138,6 +125,7 @@ function TabItem({
     <Tab
       className="flex items-center relative overflow-hidden px-4 py-1 text-slate-400 outline-none"
       style={isSelected ? { color: selectedColor } : {}}
+      tabIndex={myIndex}
     >
       <span className="z-10">{children}</span>
 

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -20,6 +20,10 @@ export type CodeGroupPropsBase = {
   copiedTooltipColor?: string;
 
   isSmallText?: boolean;
+
+  children?:
+    | React.ReactElement<CodeBlockProps>[]
+    | React.ReactElement<CodeBlockProps>;
 };
 
 export type CodeGroupProps = CodeGroupPropsBase &

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -142,7 +142,6 @@ function TabItem({
     <Tab
       className="flex items-center relative overflow-hidden px-4 py-1 text-slate-400 outline-none"
       style={isSelected ? { color: selectedColor } : {}}
-      tabIndex={myIndex}
     >
       <span className="z-10">{children}</span>
 

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { copyToClipboard } from "../utils/copyToClipboard";
 
 export function CopyToClipboardButton({
@@ -12,17 +12,22 @@ export function CopyToClipboardButton({
   copiedTooltipColor?: string;
 }) {
   const [hidden, setHidden] = useState(true);
+  const [disabled, setDisabled] = useState(true);
+
+  useEffect(() => {
+    // Hide copy button if the browser does not support it
+    if (typeof window !== "undefined" && !navigator?.clipboard) {
+      console.warn(
+          "The browser's Clipboard API is unavailable. The Clipboard API is only available on HTTPS."
+      );
+      setDisabled(true);
+    } else {
+      setDisabled(false);
+    }
+  }, []);
 
   // Hide copy button if you would copy an empty string
-  if (!textToCopy) {
-    return null;
-  }
-
-  // Hide copy button if the browser does not support it
-  if (typeof window !== "undefined" && !navigator?.clipboard) {
-    console.warn(
-      "The browser's Clipboard API is unavailable. The Clipboard API is only available on HTTPS."
-    );
+  if (!textToCopy || disabled) {
     return null;
   }
 

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -19,7 +19,7 @@ export function CopyToClipboardButton({
   }
 
   // Hide copy button if the browser does not support it
-  if (typeof window !== 'undefined' && !navigator?.clipboard) {
+  if (typeof window !== "undefined" && !navigator?.clipboard) {
     console.warn(
       "The browser's Clipboard API is unavailable. The Clipboard API is only available on HTTPS."
     );
@@ -28,7 +28,7 @@ export function CopyToClipboardButton({
 
   return (
     <button
-      aria-label={'Copy code to clipboard'}
+      aria-label={"Copy code to clipboard"}
       className="relative group"
       onClick={async () => {
         const result = await copyToClipboard(textToCopy);

--- a/src/stories/Interactive/Button.stories.tsx
+++ b/src/stories/Interactive/Button.stories.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Button } from "../../Button";
+import { Button, ButtonProps } from "../../Button";
 import { forwardRef, useRef } from "react";
-import { Card, CardProps } from "../../Card";
 
 export default {
   title: "Interactive/Button",
@@ -25,8 +24,8 @@ Indigo.args = {
   color: "indigo",
 };
 
-const RefButton = forwardRef<"button", CardProps<"button">>((args, ref) => (
-  <Card {...args} mRef={ref} />
+const RefButton = forwardRef<"button", ButtonProps<"button">>((args, ref) => (
+  <Button {...args} mRef={ref} />
 ));
 RefButton.displayName = "RefButton";
 const RefTemplate: ComponentStory<typeof RefButton> = (args) => {


### PR DESCRIPTION
### Changes

fixes https://github.com/mintlify/mint/issues/269 but hydration warnings for ~~grouped code blocks that describe custom components will appear.~~ `tsx`, `jsx` and possibly other language blocks will appear. The ones without language or `bash` work fine without errors/pop-in.
Hydration errors are addressed in a different [Issue](https://github.com/mintlify/mint/issues/258).

### Tests

Tested locally with a starter template and also the mintlify docs:

For example: `http://localhost:3000/development` in the mintlify [docs ](https://mintlify.com/docs/development)is loading without any hydration errors or pop-in, even the code blocks,
but if you add a language like 'tsx'  instead of  `bash` or sth else ~~and a Component~~,  to the code block like so:
```tsx
<Accordion title="I am an Accordion.">
  You can put any content in here.
</Accordion>
```
the hydration will fail again. As far as I am aware this is the only Issue left regarding pop-in/hydration of the code blocks.
So far I observerd that any code block, nested in `p` , grouped and highlighted works, except the ones with `tsx` or `jsx` as language.
I will try to narrow it down more, could also be related to the kind of highlighting that is done on the code.