### PR TITLE
Investigate tool tip z index on code groups

### DIFF
--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -1,5 +1,4 @@
 import clsx from "clsx";
-import { useEffect, useState } from "react";
 import { getNodeText } from "../utils/getNodeText";
 import { ReactElement } from "react";
 

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -64,7 +64,7 @@ export function CodeGroup({
     <Tab.Group
       as="div"
       onChange={setSelectedIndex as any}
-      className="not-prose gray-frame"
+      className="mt-5 mb-8 not-prose gray-frame"
     >
       <div className="flex text-xs leading-6 rounded-tl-xl pt-2">
         <Tab.List className="flex">

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -64,7 +64,7 @@ export function CodeGroup({
     <Tab.Group
       as="div"
       onChange={setSelectedIndex as any}
-      className="mt-5 mb-8 not-prose gray-frame"
+      className="not-prose gray-frame"
     >
       <div className="flex text-xs leading-6 rounded-tl-xl pt-2">
         <Tab.List className="flex">

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -29,7 +29,7 @@ export function CopyToClipboardButton({
   return (
     <button
       aria-label={'Copy code to clipboard'}
-      className="relative group"
+      className="z-40 relative group"
       onClick={async () => {
         const result = await copyToClipboard(textToCopy);
         if (result === "success") {

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -68,7 +68,7 @@ function Tooltip({
   return (
     <div
       className={clsx(
-        "z-40 absolute bottom-full left-1/2 mb-3.5 pb-1 -translate-x-1/2",
+        "z-50 absolute bottom-full left-1/2 mb-3.5 pb-1 -translate-x-1/2",
         className
       )}
     >

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -29,7 +29,7 @@ export function CopyToClipboardButton({
   return (
     <button
       aria-label={'Copy code to clipboard'}
-      className="z-40 relative group"
+      className="relative group"
       onClick={async () => {
         const result = await copyToClipboard(textToCopy);
         if (result === "success") {
@@ -68,7 +68,7 @@ function Tooltip({
   return (
     <div
       className={clsx(
-        "absolute bottom-full left-1/2 mb-3.5 pb-1 -translate-x-1/2",
+        "z-40 absolute bottom-full left-1/2 mb-3.5 pb-1 -translate-x-1/2",
         className
       )}
     >

--- a/src/stories/Interactive/Button.stories.tsx
+++ b/src/stories/Interactive/Button.stories.tsx
@@ -1,9 +1,8 @@
 import * as React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
-import { Button } from "../../Button";
+import { Button, ButtonProps } from "../../Button";
 import { forwardRef, useRef } from "react";
-import { Card, CardProps } from "../../Card";
 
 export default {
   title: "Interactive/Button",
@@ -25,8 +24,8 @@ Indigo.args = {
   color: "indigo",
 };
 
-const RefButton = forwardRef<"button", CardProps<"button">>((args, ref) => (
-  <Card {...args} mRef={ref} />
+const RefButton = forwardRef<"button", ButtonProps<"button">>((args, ref) => (
+  <Button {...args} mRef={ref} />
 ));
 RefButton.displayName = "RefButton";
 const RefTemplate: ComponentStory<typeof RefButton> = (args) => {

--- a/src/stories/Interactive/Code/CodeGroup.stories.tsx
+++ b/src/stories/Interactive/Code/CodeGroup.stories.tsx
@@ -10,7 +10,7 @@ export default {
 } as ComponentMeta<typeof CodeGroup>;
 
 const Template: ComponentStory<typeof CodeGroup> = (args) => (
-  <CodeGroup {...args} />
+    <CodeGroup {...args} > {args.children}</CodeGroup>
 );
 
 const TemplateInsideAccordion: ComponentStory<typeof CodeGroup> = (args) => (
@@ -19,7 +19,7 @@ const TemplateInsideAccordion: ComponentStory<typeof CodeGroup> = (args) => (
     description="Testing to see the CodeGroup shrinks to fit inside an Accordion"
     defaultOpen={true}
   >
-    <CodeGroup {...args} />
+    <CodeGroup {...args} > {args.children}</CodeGroup>
   </Accordion>
 );
 

--- a/src/stories/Interactive/Code/CodeGroup.stories.tsx
+++ b/src/stories/Interactive/Code/CodeGroup.stories.tsx
@@ -7,10 +7,17 @@ import { CodeBlock, CodeGroup } from "../../../Code";
 export default {
   title: "Interactive/Code/CodeGroup",
   component: CodeGroup,
+  decorators: [
+    (Story) => (
+      <div className={"mt-6"}>
+        <Story />
+      </div>
+    ),
+  ],
 } as ComponentMeta<typeof CodeGroup>;
 
 const Template: ComponentStory<typeof CodeGroup> = (args) => (
-    <CodeGroup {...args}>{args.children}</CodeGroup>
+  <CodeGroup {...args}>{args.children}</CodeGroup>
 );
 
 const TemplateInsideAccordion: ComponentStory<typeof CodeGroup> = (args) => (

--- a/src/stories/Interactive/Code/CodeGroup.stories.tsx
+++ b/src/stories/Interactive/Code/CodeGroup.stories.tsx
@@ -10,7 +10,7 @@ export default {
 } as ComponentMeta<typeof CodeGroup>;
 
 const Template: ComponentStory<typeof CodeGroup> = (args) => (
-    <CodeGroup {...args} > {args.children}</CodeGroup>
+    <CodeGroup {...args}>{args.children}</CodeGroup>
 );
 
 const TemplateInsideAccordion: ComponentStory<typeof CodeGroup> = (args) => (
@@ -19,7 +19,7 @@ const TemplateInsideAccordion: ComponentStory<typeof CodeGroup> = (args) => (
     description="Testing to see the CodeGroup shrinks to fit inside an Accordion"
     defaultOpen={true}
   >
-    <CodeGroup {...args} > {args.children}</CodeGroup>
+    <CodeGroup {...args}>{args.children}</CodeGroup>
   </Accordion>
 );
 

--- a/src/stories/Interactive/Code/CodeGroup.stories.tsx
+++ b/src/stories/Interactive/Code/CodeGroup.stories.tsx
@@ -16,17 +16,20 @@ export default {
   ],
 } as ComponentMeta<typeof CodeGroup>;
 
-const Template: ComponentStory<typeof CodeGroup> = (args) => (
-  <CodeGroup {...args}>{args.children}</CodeGroup>
+const Template: ComponentStory<typeof CodeGroup> = ({ children, ...props }) => (
+  <CodeGroup {...props}>{children}</CodeGroup>
 );
 
-const TemplateInsideAccordion: ComponentStory<typeof CodeGroup> = (args) => (
+const TemplateInsideAccordion: ComponentStory<typeof CodeGroup> = ({
+  children,
+  ...props
+}) => (
   <Accordion
     title="Accordion"
     description="Testing to see the CodeGroup shrinks to fit inside an Accordion"
     defaultOpen={true}
   >
-    <CodeGroup {...args}>{args.children}</CodeGroup>
+    <CodeGroup {...props}>{children}</CodeGroup>
   </Accordion>
 );
 


### PR DESCRIPTION
Investigates https://github.com/mintlify/components/issues/42

I added a Margin to the CodeGroup like with the CodeBlock since z-index won't work when the tooltip is out of bounds, for example in storybook it will not work

- with z-index (no change in storybook):
![image](https://user-images.githubusercontent.com/34443492/215113497-fde9b643-78d9-45d6-9af0-b969bcf529d8.png)
- normal CodeBlock
![image](https://user-images.githubusercontent.com/34443492/215113921-4a802c8e-7883-4c73-9a86-1a0e9b019dd8.png)
![image](https://user-images.githubusercontent.com/34443492/215113959-a81db6af-736f-4f77-b455-1062644c3852.png)

Adding the margin makes the group behave the same way as the CodeBlock, but I am not sure if that is desired or will break the layout in some places without adjustments in the client.