### PR TITLE
Add onCopied callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/components",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Open-source library of UI components made with React and TailwindCSS.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -3,6 +3,7 @@ import { getNodeText } from "../utils/getNodeText";
 import { ComponentPropsWithoutRef, ReactElement } from "react";
 
 import { CopyToClipboardButton } from "./CopyToClipboardButton";
+import { CopyToClipboardResult } from "../utils/copyToClipboard";
 
 export interface CodeBlockPropsBase {
   filename?: string;
@@ -18,6 +19,10 @@ export interface CodeBlockPropsBase {
    * Background color for the tooltip saying `Copied` when clicking the clipboard button.
    */
   copiedTooltipColor?: string;
+  /**
+   * The callback function when a user clicks on the copied to clipboard button
+   */
+  onCopied?: (result: CopyToClipboardResult, textToCopy?: string) => {};
 }
 
 export type CodeBlockProps = CodeBlockPropsBase &
@@ -28,6 +33,7 @@ export function CodeBlock({
   filenameColor,
   tooltipColor,
   copiedTooltipColor,
+  onCopied,
   children,
   className,
   ...props
@@ -37,6 +43,7 @@ export function CodeBlock({
       textToCopy={getNodeText(children)}
       tooltipColor={tooltipColor ?? filenameColor}
       copiedTooltipColor={copiedTooltipColor ?? tooltipColor ?? filenameColor}
+      onCopied={onCopied}
     />
   );
 

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -4,6 +4,7 @@ import { getNodeText } from "../utils/getNodeText";
 import { CopyToClipboardButton } from "./CopyToClipboardButton";
 import React, { ComponentPropsWithoutRef } from "react";
 import { CodeBlockProps } from "./CodeBlock";
+import { CopyToClipboardResult } from "../utils/copyToClipboard";
 
 export type CodeGroupPropsBase = {
   /**
@@ -18,6 +19,10 @@ export type CodeGroupPropsBase = {
    * Background color for the tooltip saying `Copied` when clicking the clipboard button.
    */
   copiedTooltipColor?: string;
+  /**
+   * The callback function when a user clicks on the copied to clipboard button
+   */
+  onCopied?: (result: CopyToClipboardResult, textToCopy?: string) => {};
 
   isSmallText?: boolean;
 
@@ -41,6 +46,7 @@ export function CodeGroup({
   selectedColor,
   tooltipColor,
   copiedTooltipColor,
+  onCopied,
   isSmallText,
 }: CodeGroupProps) {
   if (children == null) {
@@ -76,21 +82,22 @@ export function CodeGroup({
               </>
             ))}
             <div
-                className={clsx(
-                    "flex-auto flex justify-end bg-codeblock-tabs border-y border-slate-500/30 pr-4 rounded-tr",
-                    selectedIndex === childArr?.length - 1
-                        ? "rounded-tl border-l"
-                        : ""
-                )}
+              className={clsx(
+                "flex-auto flex justify-end bg-codeblock-tabs border-y border-slate-500/30 pr-4 rounded-tr",
+                selectedIndex === childArr?.length - 1
+                  ? "rounded-tl border-l"
+                  : ""
+              )}
             >
               <CopyToClipboardButton
-                  textToCopy={getNodeText(
-                      childArr[selectedIndex]?.props?.children
-                  )}
-                  tooltipColor={tooltipColor ?? selectedColor}
-                  copiedTooltipColor={
-                    copiedTooltipColor ?? tooltipColor ?? selectedColor
-                  }
+                textToCopy={getNodeText(
+                  childArr[selectedIndex]?.props?.children
+                )}
+                tooltipColor={tooltipColor ?? selectedColor}
+                copiedTooltipColor={
+                  copiedTooltipColor ?? tooltipColor ?? selectedColor
+                }
+                onCopied={onCopied}
               />
             </div>
           </>

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -1,15 +1,20 @@
 import clsx from "clsx";
 import { ReactNode, useEffect, useState } from "react";
-import { copyToClipboard } from "../utils/copyToClipboard";
+import {
+  copyToClipboard,
+  CopyToClipboardResult,
+} from "../utils/copyToClipboard";
 
 export function CopyToClipboardButton({
   textToCopy,
   tooltipColor = "#002937",
   copiedTooltipColor = tooltipColor,
+  onCopied,
 }: {
   textToCopy: string;
   tooltipColor?: string;
   copiedTooltipColor?: string;
+  onCopied?: (result: CopyToClipboardResult, textToCopy?: string) => {};
 }) {
   const [hidden, setHidden] = useState(true);
   const [disabled, setDisabled] = useState(true);
@@ -37,6 +42,9 @@ export function CopyToClipboardButton({
       className="relative group"
       onClick={async () => {
         const result = await copyToClipboard(textToCopy);
+        if (onCopied) {
+          onCopied(result, textToCopy);
+        }
         if (result === "success") {
           setHidden(false);
           setTimeout(() => {

--- a/src/stories/Interactive/Code/CodeBlock.stories.tsx
+++ b/src/stories/Interactive/Code/CodeBlock.stories.tsx
@@ -32,12 +32,18 @@ WithFileName.args = {
   filename: "Example File Name",
 };
 
+export const WithOnCopiedCallback = Template.bind({});
+WithFileName.args = {
+  filename: "Example File Name",
+  onCopy: () => console.log("Copied!"),
+};
+
 export const FileNameGreenAccents = Template.bind({});
 FileNameGreenAccents.args = {
   filename: "Example File Name",
   filenameColor: "#00ff00",
   tooltipColor: "#00AA00",
-  copiedTooltipColor: "#00DD00"
+  copiedTooltipColor: "#00DD00",
 };
 
 export const NoFileName = Template.bind({});

--- a/src/utils/copyToClipboard.ts
+++ b/src/utils/copyToClipboard.ts
@@ -1,4 +1,8 @@
-export async function copyToClipboard(text: string) {
+export type CopyToClipboardResult = "success" | "error";
+
+export async function copyToClipboard(
+  text: string
+): Promise<CopyToClipboardResult> {
   if (!text) {
     console.warn("Called copyToClipboard() with empty text");
   }
@@ -7,7 +11,6 @@ export async function copyToClipboard(text: string) {
     console.error(
       "The Clipboard API was unavailable. The Clipboard API is only available client-side in browsers using HTTPS."
     );
-    return;
   }
 
   try {


### PR DESCRIPTION
# Summary

Add `onCopied` as an optional property for codeblocks and codegroups so it can be used for event logging in analytics.

### Testing

- Open Storybook and click it. You should see a response in the `Actions` tab

<img width="858" alt="CleanShot 2023-02-05 at 15 38 36@2x" src="https://user-images.githubusercontent.com/44352119/216852497-7d2235b7-c1a9-4166-9582-b48edb03be0d.png">
