### PR TITLE
Code block z index

### DIFF
--- a/src/Accordion/index.ts
+++ b/src/Accordion/index.ts
@@ -1,4 +1,4 @@
-import Accordion from './Accordion';
-import AccordionGroup from './AccordionGroup';
+import Accordion from "./Accordion";
+import AccordionGroup from "./AccordionGroup";
 
 export { Accordion, AccordionGroup };

--- a/src/Callouts.tsx
+++ b/src/Callouts.tsx
@@ -8,14 +8,24 @@ type CalloutProps = {
   childrenClassName: string;
 };
 
-function CalloutTemplate({ children, icon, className, childrenClassName }: CalloutProps) {
+function CalloutTemplate({
+  children,
+  icon,
+  className,
+  childrenClassName,
+}: CalloutProps) {
   return (
     <div
       className={clsx("px-5 py-4 mb-4 overflow-hidden rounded-xl", className)}
     >
       <div className="flex items-start space-x-3">
         <div className="mt-0.5 w-4">{icon}</div>
-        <div className={clsx("flex-1 text-sm prose overflow-x-auto", childrenClassName)}>
+        <div
+          className={clsx(
+            "flex-1 text-sm prose overflow-x-auto",
+            childrenClassName
+          )}
+        >
           {children}
         </div>
       </div>

--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -38,7 +38,9 @@ export function CodeBlock({
   className,
   ...props
 }: CodeBlockProps) {
-  const Button = (props: Partial<ComponentPropsWithoutRef<typeof CopyToClipboardButton>>) => (
+  const Button = (
+    props: Partial<ComponentPropsWithoutRef<typeof CopyToClipboardButton>>
+  ) => (
     <CopyToClipboardButton
       textToCopy={getNodeText(children)}
       tooltipColor={tooltipColor ?? filenameColor}
@@ -62,9 +64,7 @@ export function CodeBlock({
           <Button />
         </CodeTabBar>
       ) : null}
-      {!filename && (
-          <Button className="z-10 absolute top-5 right-5"  />
-      )}
+      {!filename && <Button className="z-10 absolute top-5 right-5" />}
       <div
         className="code-in-gray-frame children:!my-0 children:!shadow-none children:!bg-transparent"
         style={{ fontVariantLigatures: "none" }}

--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -64,7 +64,7 @@ export function CodeBlock({
           <Button />
         </CodeTabBar>
       ) : null}
-      {!filename && <Button className="z-10 absolute top-5 right-5" />}
+      {!filename && <Button className="absolute top-5 right-5" />}
       <div
         className="code-in-gray-frame children:!my-0 children:!shadow-none children:!bg-transparent"
         style={{ fontVariantLigatures: "none" }}

--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -61,7 +61,7 @@ export function CodeBlock({
     >
       {filename ? (
         <CodeTabBar filename={filename} filenameColor={filenameColor}>
-          <Button className={'relative'} />
+          <Button className={"relative"} />
         </CodeTabBar>
       ) : (
         <Button className="absolute top-5 right-5" />

--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -38,12 +38,13 @@ export function CodeBlock({
   className,
   ...props
 }: CodeBlockProps) {
-  const Button = () => (
+  const Button = (props: Partial<ComponentPropsWithoutRef<typeof CopyToClipboardButton>>) => (
     <CopyToClipboardButton
       textToCopy={getNodeText(children)}
       tooltipColor={tooltipColor ?? filenameColor}
       copiedTooltipColor={copiedTooltipColor ?? tooltipColor ?? filenameColor}
       onCopied={onCopied}
+      {...props}
     />
   );
 
@@ -62,9 +63,7 @@ export function CodeBlock({
         </CodeTabBar>
       ) : null}
       {!filename && (
-        <div className="z-10 absolute top-5 right-5">
-          <Button />
-        </div>
+          <Button className="z-10 absolute top-5 right-5"  />
       )}
       <div
         className="code-in-gray-frame children:!my-0 children:!shadow-none children:!bg-transparent"

--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -61,7 +61,7 @@ export function CodeBlock({
     >
       {filename ? (
         <CodeTabBar filename={filename} filenameColor={filenameColor}>
-          <Button />
+          <Button className={'relative'} />
         </CodeTabBar>
       ) : (
         <Button className="absolute top-5 right-5" />

--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -63,8 +63,9 @@ export function CodeBlock({
         <CodeTabBar filename={filename} filenameColor={filenameColor}>
           <Button />
         </CodeTabBar>
-      ) : null}
-      {!filename && <Button className="absolute top-5 right-5" />}
+      ) : (
+        <Button className="absolute top-5 right-5" />
+      )}
       <div
         className="code-in-gray-frame children:!my-0 children:!shadow-none children:!bg-transparent"
         style={{ fontVariantLigatures: "none" }}

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -98,6 +98,7 @@ export function CodeGroup({
                   copiedTooltipColor ?? tooltipColor ?? selectedColor
                 }
                 onCopied={onCopied}
+                className={'relative'}
               />
             </div>
           </>

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -98,7 +98,7 @@ export function CodeGroup({
                   copiedTooltipColor ?? tooltipColor ?? selectedColor
                 }
                 onCopied={onCopied}
-                className={'relative'}
+                className={"relative"}
               />
             </div>
           </>

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -1,5 +1,10 @@
 import clsx from "clsx";
-import {ComponentPropsWithoutRef, ReactNode, useEffect, useState} from "react";
+import {
+  ComponentPropsWithoutRef,
+  ReactNode,
+  useEffect,
+  useState,
+} from "react";
 import {
   copyToClipboard,
   CopyToClipboardResult,
@@ -16,7 +21,7 @@ export function CopyToClipboardButton({
   tooltipColor?: string;
   copiedTooltipColor?: string;
   onCopied?: (result: CopyToClipboardResult, textToCopy?: string) => void;
-} & ComponentPropsWithoutRef<'button'>) {
+} & ComponentPropsWithoutRef<"button">) {
   const [hidden, setHidden] = useState(true);
   const [disabled, setDisabled] = useState(true);
 

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { ReactNode, useEffect, useState } from "react";
+import {ComponentPropsWithoutRef, ReactNode, useEffect, useState} from "react";
 import {
   copyToClipboard,
   CopyToClipboardResult,
@@ -10,12 +10,13 @@ export function CopyToClipboardButton({
   tooltipColor = "#002937",
   copiedTooltipColor = tooltipColor,
   onCopied,
+  ...props
 }: {
   textToCopy: string;
   tooltipColor?: string;
   copiedTooltipColor?: string;
   onCopied?: (result: CopyToClipboardResult, textToCopy?: string) => void;
-}) {
+} & ComponentPropsWithoutRef<'button'>) {
   const [hidden, setHidden] = useState(true);
   const [disabled, setDisabled] = useState(true);
 
@@ -52,6 +53,7 @@ export function CopyToClipboardButton({
           }, 2000);
         }
       }}
+      {...props}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -58,7 +58,7 @@ export function CopyToClipboardButton({
           }, 2000);
         }
       }}
-      className={clsx(className, "group")}
+      className={clsx("group", className)}
       {...props}
     >
       <svg

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -15,6 +15,7 @@ export function CopyToClipboardButton({
   tooltipColor = "#002937",
   copiedTooltipColor = tooltipColor,
   onCopied,
+  className,
   ...props
 }: {
   textToCopy: string;
@@ -45,7 +46,6 @@ export function CopyToClipboardButton({
   return (
     <button
       aria-label={"Copy code to clipboard"}
-      className="relative group"
       onClick={async () => {
         const result = await copyToClipboard(textToCopy);
         if (onCopied) {
@@ -58,6 +58,7 @@ export function CopyToClipboardButton({
           }, 2000);
         }
       }}
+      className={clsx(className, "group")}
       {...props}
     >
       <svg

--- a/src/Code/index.ts
+++ b/src/Code/index.ts
@@ -1,5 +1,10 @@
 import { CodeBlock, CodeBlockProps, CodeBlockPropsBase } from "./CodeBlock";
 import { CodeGroup, CodeGroupProps, CodeGroupPropsBase } from "./CodeGroup";
 
-export type { CodeGroupPropsBase, CodeBlockPropsBase, CodeGroupProps, CodeBlockProps }
+export type {
+  CodeGroupPropsBase,
+  CodeBlockPropsBase,
+  CodeGroupProps,
+  CodeBlockProps,
+};
 export { CodeBlock, CodeGroup };

--- a/src/Expandable/index.ts
+++ b/src/Expandable/index.ts
@@ -1,3 +1,3 @@
-import Expandable from './Expandable';
+import Expandable from "./Expandable";
 
 export { Expandable };

--- a/src/stories/Interactive/Button.stories.tsx
+++ b/src/stories/Interactive/Button.stories.tsx
@@ -24,9 +24,9 @@ Indigo.args = {
   color: "indigo",
 };
 
-const RefButton = forwardRef<"button" | undefined, ButtonProps<"button">>((args, ref) => (
-  <Button {...args} mRef={ref} />
-));
+const RefButton = forwardRef<"button" | undefined, ButtonProps<"button">>(
+  (args, ref) => <Button {...args} mRef={ref} />
+);
 RefButton.displayName = "RefButton";
 const RefTemplate: ComponentStory<typeof RefButton> = (args) => {
   const ref = useRef<"button">();


### PR DESCRIPTION
Fixes issue with z-index on Codeblocks without names and improves props of CodeBlock button to reduce nesting.

I ran prettier in the end, formatting some other files as well.
I could add git hooks in a seperate PR to automatically run eslint/prettier on every commit, which really helps with maintaining.