### PR TITLE
refactor: remove `copiedToolTipColor` from `code` coponents

### DIFF
--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -18,7 +18,6 @@ export interface CodeBlockPropsBase {
   /**
    * Background color for the tooltip saying `Copied` when clicking the clipboard button.
    */
-  copiedTooltipColor?: string;
   /**
    * The callback function when a user clicks on the copied to clipboard button
    */
@@ -32,7 +31,6 @@ export function CodeBlock({
   filename,
   filenameColor,
   tooltipColor,
-  copiedTooltipColor,
   onCopied,
   children,
   className,
@@ -44,7 +42,6 @@ export function CodeBlock({
     <CopyToClipboardButton
       textToCopy={getNodeText(children)}
       tooltipColor={tooltipColor ?? filenameColor}
-      copiedTooltipColor={copiedTooltipColor ?? tooltipColor ?? filenameColor}
       onCopied={onCopied}
       {...props}
     />

--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -16,9 +16,6 @@ export interface CodeBlockPropsBase {
    */
   tooltipColor?: string;
   /**
-   * Background color for the tooltip saying `Copied` when clicking the clipboard button.
-   */
-  /**
    * The callback function when a user clicks on the copied to clipboard button
    */
   onCopied?: (result: CopyToClipboardResult, textToCopy?: string) => void;

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -16,9 +16,6 @@ export type CodeGroupPropsBase = {
    */
   tooltipColor?: string;
   /**
-   * Background color for the tooltip saying `Copied` when clicking the clipboard button.
-   */
-  /**
    * The callback function when a user clicks on the copied to clipboard button
    */
   onCopied?: (result: CopyToClipboardResult, textToCopy?: string) => void;

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -18,7 +18,6 @@ export type CodeGroupPropsBase = {
   /**
    * Background color for the tooltip saying `Copied` when clicking the clipboard button.
    */
-  copiedTooltipColor?: string;
   /**
    * The callback function when a user clicks on the copied to clipboard button
    */
@@ -45,7 +44,6 @@ export function CodeGroup({
   children,
   selectedColor,
   tooltipColor,
-  copiedTooltipColor,
   onCopied,
   isSmallText,
 }: CodeGroupProps) {
@@ -94,9 +92,6 @@ export function CodeGroup({
                   childArr[selectedIndex]?.props?.children
                 )}
                 tooltipColor={tooltipColor ?? selectedColor}
-                copiedTooltipColor={
-                  copiedTooltipColor ?? tooltipColor ?? selectedColor
-                }
                 onCopied={onCopied}
                 className={"relative"}
               />

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -13,14 +13,12 @@ import {
 export function CopyToClipboardButton({
   textToCopy,
   tooltipColor = "#002937",
-  copiedTooltipColor = tooltipColor,
   onCopied,
   className,
   ...props
 }: {
   textToCopy: string;
   tooltipColor?: string;
-  copiedTooltipColor?: string;
   onCopied?: (result: CopyToClipboardResult, textToCopy?: string) => void;
 } & ComponentPropsWithoutRef<"button">) {
   const [hidden, setHidden] = useState(true);
@@ -69,7 +67,7 @@ export function CopyToClipboardButton({
         <path d="M320 64H280h-9.6C263 27.5 230.7 0 192 0s-71 27.5-78.4 64H104 64C28.7 64 0 92.7 0 128V448c0 35.3 28.7 64 64 64H320c35.3 0 64-28.7 64-64V128c0-35.3-28.7-64-64-64zM80 112v24c0 13.3 10.7 24 24 24h88 88c13.3 0 24-10.7 24-24V112h16c8.8 0 16 7.2 16 16V448c0 8.8-7.2 16-16 16H64c-8.8 0-16-7.2-16-16V128c0-8.8 7.2-16 16-16H80zm88-32a24 24 0 1 1 48 0 24 24 0 1 1 -48 0zM136 272a24 24 0 1 0 -48 0 24 24 0 1 0 48 0zm40-16c-8.8 0-16 7.2-16 16s7.2 16 16 16h96c8.8 0 16-7.2 16-16s-7.2-16-16-16H176zm0 96c-8.8 0-16 7.2-16 16s7.2 16 16 16h96c8.8 0 16-7.2 16-16s-7.2-16-16-16H176zm-64 40a24 24 0 1 0 0-48 24 24 0 1 0 0 48z" />
       </svg>
       <Tooltip
-        color={hidden ? tooltipColor : copiedTooltipColor}
+        color={tooltipColor}
         className={`${hidden ? "invisible" : undefined} group-hover:visible`}
       >
         {hidden ? "Copy" : "Copied"}

--- a/src/stories/Interactive/Code/CodeBlock.stories.tsx
+++ b/src/stories/Interactive/Code/CodeBlock.stories.tsx
@@ -43,7 +43,6 @@ FileNameGreenAccents.args = {
   filename: "Example File Name",
   filenameColor: "#00ff00",
   tooltipColor: "#00AA00",
-  copiedTooltipColor: "#00DD00",
 };
 
 export const NoFileName = Template.bind({});

--- a/src/stories/Interactive/Code/CodeGroup.stories.tsx
+++ b/src/stories/Interactive/Code/CodeGroup.stories.tsx
@@ -36,7 +36,6 @@ const TemplateInsideAccordion: ComponentStory<typeof CodeGroup> = ({
 export const OneChild = Template.bind({});
 OneChild.args = {
   selectedColor: "#ffff00",
-  copiedTooltipColor: "#0000ff",
   children: (
     <CodeBlock filename="Very Very Very Long Filename">
       <p>Example Code</p>
@@ -47,7 +46,6 @@ OneChild.args = {
 export const ThreeChildren = Template.bind({});
 ThreeChildren.args = {
   selectedColor: "#ffff00",
-  copiedTooltipColor: "#0000ff",
   children: [
     <CodeBlock filename="Name 1">
       <p>First Page of Code</p>
@@ -69,7 +67,6 @@ ThreeChildren.args = {
 export const InsideAccordionWithTwoChildren = TemplateInsideAccordion.bind({});
 InsideAccordionWithTwoChildren.args = {
   selectedColor: "#ffff00",
-  copiedTooltipColor: "#0000ff",
   children: [
     <CodeBlock filename="Name 1">
       <p>First Page of Code</p>


### PR DESCRIPTION
This PR will remove `copiedToToolTipColor` prop from all `CodeBlock` components and component calls as mentioned in issue #46 

### Changes Proposed
- Removed `*copiedTooltipColor*,` from `CodeBlockPropsBase` interface
- Removed `*copiedTooltipColor*,` from `CodeBlock` component
- Removed `*copiedTooltipColor*,` from `CopyToClipboardButton` component
- Removed `*copiedTooltipColor*,` from `ToolTip` component call
- Removed `*copiedTooltipColor*,` from `CopyToClipboardButton` component call
- Removed `*copiedTooltipColor*,` from `CodeGroup` component 
- Removed `*copiedTooltipColor*,` from `CodeBlock` stories 
- Removed `*copiedTooltipColor*,` from `CodeGroup` stories

closes #46 

### Screenshots
- Prev

![Screenshot from 2023-02-08 11-05-11](https://user-images.githubusercontent.com/86586277/217449159-d2a3d7c1-ce54-4bec-9f89-ef5744730486.png)

![Screenshot from 2023-02-08 11-05-25](https://user-images.githubusercontent.com/86586277/217449171-3edca398-24be-411d-86ff-03a93beacb62.png)

- Current

![Screenshot from 2023-02-08 11-47-19](https://user-images.githubusercontent.com/86586277/217450178-884920ff-d8ad-4277-ad35-4ed8a1a5a952.png)

![Screenshot from 2023-02-08 11-48-55](https://user-images.githubusercontent.com/86586277/217450362-9461c53a-47f8-4ff6-b26c-d6254f531d35.png)

![Screenshot from 2023-02-08 11-22-27](https://user-images.githubusercontent.com/86586277/217450215-c97587b7-d66e-46e4-841d-75caf06dbb87.png)

### Additional Context
It was really fun to contribute here. If further changes are applicable a brief explanation would be appreciated. Thank You.
