### PR TITLE
feat: icon prop supports image in card component

### DIFF
--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -52,6 +52,30 @@ export function Card<T extends ElementType = "div">({
     ? { target: "_blank", rel: "noreferrer" }
     : {};
 
+  let testIconisImage: boolean = false;
+
+  if (typeof icon === "string") {
+    testIconisImage = icon.startsWith("http://") || icon.startsWith("https://");
+  }
+
+  const renderIcon: JSX.Element = (
+    <>
+      {icon ? (
+        testIconisImage ? (
+          <img
+            src={icon as string}
+            alt={title}
+            className="h-6 w-6 rounded-full object-cover object-center"
+          />
+        ) : (
+          <div className="h-6 w-6 fill-slate-800 dark:fill-slate-100 text-slate-800 dark:text-slate-100">
+            {icon}
+          </div>
+        )
+      ) : null}
+    </>
+  );
+
   return (
     <Component
       className={clsx(
@@ -63,11 +87,7 @@ export function Card<T extends ElementType = "div">({
       {...props}
       ref={mRef as Ref<any>}
     >
-      {icon ? (
-        <div className="h-6 w-6 fill-slate-800 dark:fill-slate-100 text-slate-800 dark:text-slate-100">
-          {icon}
-        </div>
-      ) : null}
+      {renderIcon}
       <h2
         className={clsx(
           "font-semibold text-base text-slate-800 dark:text-white",

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -52,20 +52,16 @@ export function Card<T extends ElementType = "div">({
     ? { target: "_blank", rel: "noreferrer" }
     : {};
 
-  let testIconisImage: boolean = false;
-
-  if (typeof icon === "string") {
-    testIconisImage = icon.startsWith("http://") || icon.startsWith("https://");
-  }
+  const isImageSrc: boolean = typeof icon === "string";
 
   const renderIcon: JSX.Element = (
     <>
       {icon ? (
-        testIconisImage ? (
+        isImageSrc ? (
           <img
             src={icon as string}
             alt={title}
-            className="h-6 w-6 rounded-full object-cover object-center"
+            className="h-6 w-6 object-cover object-center"
           />
         ) : (
           <div className="h-6 w-6 fill-slate-800 dark:fill-slate-100 text-slate-800 dark:text-slate-100">

--- a/src/stories/Display/Cards/Card.stories.tsx
+++ b/src/stories/Display/Cards/Card.stories.tsx
@@ -26,10 +26,19 @@ const icon = (
   </svg>
 );
 
+const imageIcon = "https://avatars.githubusercontent.com/u/93011474?s=200&v=4";
+
 export const WithCustomIcon = Template.bind({});
 WithCustomIcon.args = {
   title: "Card Title",
   icon,
+  children: "Card text.",
+};
+
+export const WithCustomImageIcon = Template.bind({});
+WithCustomImageIcon.args = {
+  title: "Card Title",
+  icon: imageIcon,
   children: "Card text.",
 };
 


### PR DESCRIPTION
This PR will add a feature of passing custom image icon link in icon prop.
closes #50 
### Changes Proposed
- Added a conditional checking if the icon value is a image link (starts with http:// or https://)
- Based on the condition it will render img element otherwise passed element
- Styled img tag with tailwindcss and made the icon rounded
- Updated docs in storybook card stories

### Screenshots
![Screenshot from 2023-02-09 11-19-22](https://user-images.githubusercontent.com/86586277/217767928-2753589c-dd4c-4ed2-a021-12ee81dcdae3.png)
![Screenshot from 2023-02-09 14-25-13](https://user-images.githubusercontent.com/86586277/217765596-78c890fa-f73b-45f8-b0ce-3a998072d9a6.png)

