### PR TITLE
Publish @mintlify/components 0.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/components",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Open-source library of UI components made with React and TailwindCSS.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -96,7 +96,7 @@
   },
   "dependencies": {
     "assert": "^2.0.0",
-    "clsx": "^1.1.1",
+    "clsx": "^1.2.1",
     "is-absolute-url": "^4.0.1",
     "lodash.set": "^4.3.2"
   },

--- a/src/Accordion/Accordion.tsx
+++ b/src/Accordion/Accordion.tsx
@@ -1,5 +1,5 @@
-import clsx from 'clsx';
-import { ReactNode, useState } from 'react';
+import { clsx } from 'clsx';
+import React, { ReactNode, useState } from 'react';
 
 import AccordionCover from './AccordionCover';
 import getAccordionStyleFromVariant from './getAccordionStyleFromType';

--- a/src/Accordion/AccordionCover.tsx
+++ b/src/Accordion/AccordionCover.tsx
@@ -1,4 +1,5 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
+import React from 'react';
 import { ReactNode } from 'react';
 
 import { ExpandableItemCoverIcon } from '../Expandable/ExpandableCover';

--- a/src/Api/ApiPlayground.tsx
+++ b/src/Api/ApiPlayground.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import set from 'lodash.set';
 import React, { ReactNode, useState } from 'react';
 

--- a/src/Api/RequestMethodBubble.tsx
+++ b/src/Api/RequestMethodBubble.tsx
@@ -1,4 +1,5 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
+import React from 'react';
 
 import { getMethodBgColor } from '../utils/apiPlaygroundColors';
 import { RequestMethods } from './types';

--- a/src/Api/inputs/ApiInput.tsx
+++ b/src/Api/inputs/ApiInput.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import React, { useState } from 'react';
 
 import { ApiInputValue, Param } from '../types';

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -1,9 +1,9 @@
-import clsx from 'clsx';
-import { ElementType, ComponentPropsWithoutRef, Ref } from 'react';
+import { clsx } from 'clsx';
+import React, { ElementType, ComponentPropsWithoutRef, Ref } from 'react';
 
 type ColorInterface = keyof typeof colors;
 
-let colors = {
+const colors = {
   indigo: [
     'bg-indigo-50 text-indigo-600 hover:bg-indigo-200 hover:text-indigo-700 focus:ring-indigo-500',
     'text-indigo-300 group-hover:text-indigo-400',
@@ -26,7 +26,7 @@ let colors = {
   ],
 };
 
-let colorsDark: Record<ColorInterface, string[]> = {
+const colorsDark: Record<ColorInterface, string[]> = {
   ...colors,
   gray: [
     'dark:bg-slate-700 dark:text-slate-100 dark:hover:bg-slate-600 dark:hover:text-white dark:focus:ring-slate-500',
@@ -82,8 +82,8 @@ export function Button<T extends ElementType = 'button'>({
   mRef,
   ...props
 }: ButtonProps<T>) {
-  let colorClasses = typeof color === 'string' ? colors[color] : color;
-  let darkColorClasses = typeof darkColor === 'string' ? colorsDark[darkColor] || [] : darkColor;
+  const colorClasses = typeof color === 'string' ? colors[color] : color;
+  const darkColorClasses = typeof darkColor === 'string' ? colorsDark[darkColor] || [] : darkColor;
 
   /**
    * If provided, use `as` or an `a` tag if linking to things with href.

--- a/src/Callouts.tsx
+++ b/src/Callouts.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { ReactNode } from 'react';
 
 type CalloutProps = {

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import isAbsoluteUrl from 'is-absolute-url';
 import React, { ComponentPropsWithoutRef, ElementType, ReactNode, Ref } from 'react';
 

--- a/src/CardGroup.tsx
+++ b/src/CardGroup.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 
 export function CardGroup({ children, cols = 2 }: { children: ReactNode; cols?: 1 | 2 | 3 | 4 }) {
   return <div className={`not-prose grid sm:grid-cols-${cols} gap-x-4`}>{children}</div>;

--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import React, { ComponentPropsWithoutRef, ForwardedRef, forwardRef, ReactElement } from 'react';
 
 import { CopyToClipboardResult } from '../utils/copyToClipboard';

--- a/src/Code/CodeGroup.tsx
+++ b/src/Code/CodeGroup.tsx
@@ -1,5 +1,5 @@
 import { Tab } from '@headlessui/react';
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import React, {
   ComponentPropsWithoutRef,
   FormEventHandler,

--- a/src/Code/CopyToClipboardButton.tsx
+++ b/src/Code/CopyToClipboardButton.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { ComponentPropsWithoutRef, ReactNode, useEffect, useState } from 'react';
 
 import { copyToClipboard, CopyToClipboardResult } from '../utils/copyToClipboard';

--- a/src/Expandable/Expandable.tsx
+++ b/src/Expandable/Expandable.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { useState } from 'react';
 
 import ExpandableCover from './ExpandableCover';

--- a/src/Expandable/ExpandableCover.tsx
+++ b/src/Expandable/ExpandableCover.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 
 function ExpandableCover({
   title,

--- a/src/Frame.tsx
+++ b/src/Frame.tsx
@@ -1,4 +1,5 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
+import React from 'react';
 
 const paddingMap = { none: '', md: 'p-8' };
 
@@ -26,7 +27,7 @@ export function Frame({
   padding: 'none' | 'md';
   lightOnly: boolean;
 }) {
-  let paddingClassName = paddingMap[padding];
+  const paddingClassName = paddingMap[padding];
 
   return (
     <div className={containerClassName}>

--- a/src/Param.tsx
+++ b/src/Param.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import React from 'react';
 
 // required and optional should be merged into a single prop that allows arbitrary text

--- a/src/PillSelect.tsx
+++ b/src/PillSelect.tsx
@@ -1,6 +1,6 @@
 import { Menu } from '@headlessui/react';
-import clsx from 'clsx';
-import { useState } from 'react';
+import { clsx } from 'clsx';
+import React, { useState } from 'react';
 
 export function PillSelect({
   options,

--- a/src/Tabs/Tab.tsx
+++ b/src/Tabs/Tab.tsx
@@ -1,4 +1,4 @@
-import clsx from 'clsx';
+import { clsx } from 'clsx';
 import { ReactNode } from 'react';
 
 export default function Tab({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5416,9 +5416,14 @@ clsx@1.1.0:
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.1.0.tgz#62937c6adfea771247c34b54d320fb99624f5702"
   integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
 
-clsx@^1.0.4, clsx@^1.1.1:
+clsx@^1.0.4:
   version "1.2.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
+  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
+
+clsx@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
 co@^4.6.0:


### PR DESCRIPTION
Also bumped `clsx` so we can use Typescript's preferred import syntax. See their release notes for details: https://github.com/lukeed/clsx/releases/tag/v1.2.0