### PR TITLE
Add ImageGroup component

### DIFF
--- a/src/ImageGroup.tsx
+++ b/src/ImageGroup.tsx
@@ -7,7 +7,7 @@ export function ImageGroup({
   className,
 }: {
   children: ReactNode;
-  cols?: number;
+  cols?: 1 | 2 | 3 | 4;
   className?: string;
 }) {
   return (

--- a/src/ImageGroup.tsx
+++ b/src/ImageGroup.tsx
@@ -1,0 +1,5 @@
+import React, { ReactNode } from 'react';
+
+export function ImageGroup({ children, cols = 2 }: { children: ReactNode; cols?: 1 | 2 }) {
+  return <div className={`not-prose grid sm:grid-cols-${cols} gap-4`}>{children}</div>;
+}

--- a/src/ImageGroup.tsx
+++ b/src/ImageGroup.tsx
@@ -1,5 +1,16 @@
+import clsx from 'clsx';
 import React, { ReactNode } from 'react';
 
-export function ImageGroup({ children, cols = 2 }: { children: ReactNode; cols?: 1 | 2 }) {
-  return <div className={`not-prose grid sm:grid-cols-${cols} gap-4`}>{children}</div>;
+export function ImageGroup({
+  children,
+  cols = 2,
+  className,
+}: {
+  children: ReactNode;
+  cols?: number;
+  className?: string;
+}) {
+  return (
+    <div className={clsx(`not-prose grid sm:grid-cols-${cols} gap-4`, className)}>{children}</div>
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 } from './Code';
 import { Expandable } from './Expandable';
 import { Frame } from './Frame';
+import { ImageGroup } from './ImageGroup';
 import { Param } from './Param';
 import { PillSelect } from './PillSelect';
 import { Tab, Tabs } from './Tabs';
@@ -53,4 +54,5 @@ export {
   Tip,
   Tab,
   Tooltip,
+  ImageGroup,
 };

--- a/src/stories/Display/ImageGroup.stories.tsx
+++ b/src/stories/Display/ImageGroup.stories.tsx
@@ -29,3 +29,9 @@ TwoColumns.args = {
   cols: 2,
   children: ThreeCards,
 };
+
+export const ThreeColumns = Template.bind({});
+ThreeColumns.args = {
+  cols: 3,
+  children: ThreeCards,
+};

--- a/src/stories/Display/ImageGroup.stories.tsx
+++ b/src/stories/Display/ImageGroup.stories.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { ImageGroup } from '../../ImageGroup';
 
 export default {
-  title: 'Display/Cards/ImageGroup',
+  title: 'Display/ImageGroup',
   component: ImageGroup,
 } as ComponentMeta<typeof ImageGroup>;
 

--- a/src/stories/Display/ImageGroup.stories.tsx
+++ b/src/stories/Display/ImageGroup.stories.tsx
@@ -10,28 +10,35 @@ export default {
 
 const Template: ComponentStory<typeof ImageGroup> = (args) => <ImageGroup {...args} />;
 
-const ThreeCards = (
+const Cards = (
   <>
     <img src="https://images.unsplash.com/photo-1541701494587-cb58502866ab?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2670&q=80" />
     <img src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2128&q=80" />
     <img src="https://images.unsplash.com/photo-1558591710-4b4a1ae0f04d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=987&q=80" />
+    <img src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2128&q=80" />
   </>
 );
 
 export const OneColumn = Template.bind({});
 OneColumn.args = {
   cols: 1,
-  children: ThreeCards,
+  children: Cards,
 };
 
 export const TwoColumns = Template.bind({});
 TwoColumns.args = {
   cols: 2,
-  children: ThreeCards,
+  children: Cards,
 };
 
 export const ThreeColumns = Template.bind({});
 ThreeColumns.args = {
   cols: 3,
-  children: ThreeCards,
+  children: Cards,
+};
+
+export const FourColumns = Template.bind({});
+FourColumns.args = {
+  cols: 4,
+  children: Cards,
 };

--- a/src/stories/Display/ImageGroup.stories.tsx
+++ b/src/stories/Display/ImageGroup.stories.tsx
@@ -1,0 +1,31 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import * as React from 'react';
+
+import { ImageGroup } from '../../ImageGroup';
+
+export default {
+  title: 'Display/Cards/ImageGroup',
+  component: ImageGroup,
+} as ComponentMeta<typeof ImageGroup>;
+
+const Template: ComponentStory<typeof ImageGroup> = (args) => <ImageGroup {...args} />;
+
+const ThreeCards = (
+  <>
+    <img src="https://images.unsplash.com/photo-1541701494587-cb58502866ab?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2670&q=80" />
+    <img src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2128&q=80" />
+    <img src="https://images.unsplash.com/photo-1558591710-4b4a1ae0f04d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=987&q=80" />
+  </>
+);
+
+export const OneColumn = Template.bind({});
+OneColumn.args = {
+  cols: 1,
+  children: ThreeCards,
+};
+
+export const TwoColumns = Template.bind({});
+TwoColumns.args = {
+  cols: 2,
+  children: ThreeCards,
+};


### PR DESCRIPTION
## Description
This PR adds the `ImageGroup` component that lets users to show two images side-by-side. Based on requirements (when the height of images aren't equal), the default value of the `cols` prop is 2. However, it's also possible to show multiple images one below the other.

The changes in this PR resolves https://github.com/mintlify/components/issues/56.

## Screenshots of changes in Storybook
|One column|Two column|Three column|Four column|
|----------|----------|------------|----------|
|![image](https://github.com/mintlify/components/assets/6391763/9904181d-4750-4904-b780-1cb49902609f)|![image](https://github.com/mintlify/components/assets/6391763/810b9d3b-9eff-47b2-b56e-06fbd2c7a802)|![Capture-2023-05-22-145539](https://github.com/mintlify/components/assets/6391763/52b23e22-c100-45de-8acf-871e08c5480e)|![Capture-2023-05-22-145714](https://github.com/mintlify/components/assets/6391763/dc31fef2-1277-4c4f-8ded-14228fe78ad4)|
