### PR TITLE
Add className prop to CardGroup

### DIFF
--- a/src/CardGroup.tsx
+++ b/src/CardGroup.tsx
@@ -1,5 +1,16 @@
+import clsx from 'clsx';
 import React, { ReactNode } from 'react';
 
-export function CardGroup({ children, cols = 2 }: { children: ReactNode; cols?: 1 | 2 | 3 | 4 }) {
-  return <div className={`not-prose grid sm:grid-cols-${cols} gap-x-4`}>{children}</div>;
+export function CardGroup({
+  children,
+  cols = 2,
+  className,
+}: {
+  children: ReactNode;
+  cols?: 1 | 2 | 3 | 4;
+  className?: string;
+}) {
+  return (
+    <div className={clsx(`not-prose grid sm:grid-cols-${cols} gap-x-4`, className)}>{children}</div>
+  );
 }


### PR DESCRIPTION
## Description
This PR adds the `className` prop to the `CardGroup` component to make the props similar to [the new `ImageGroup` component](https://github.com/mintlify/components/pull/85/files#diff-6ee38f9d587da5a4f586b06f838ac70100b90ab5c5418eeb25d82110c3712d0dR7).