### PR TITLE
add background to cover code text

### DIFF
--- a/src/Code/CodeBlock.tsx
+++ b/src/Code/CodeBlock.tsx
@@ -1,5 +1,5 @@
 import { clsx } from 'clsx';
-import React, { ComponentPropsWithoutRef, ForwardedRef, forwardRef, ReactElement } from 'react';
+import React, { ComponentPropsWithoutRef, FC, ForwardedRef, forwardRef, ReactElement } from 'react';
 
 import { CopyToClipboardResult } from '../utils/copyToClipboard';
 import { getNodeText } from '../utils/getNodeText';
@@ -36,13 +36,14 @@ export const CodeBlock = forwardRef(function CodeBlock(
   }: CodeBlockProps,
   ref: ForwardedRef<HTMLDivElement>
 ) {
-  const Button = (props: Partial<ComponentPropsWithoutRef<typeof CopyToClipboardButton>>) => (
-    <CopyToClipboardButton
-      textToCopy={getNodeText(children)}
-      tooltipColor={tooltipColor ?? filenameColor}
-      onCopied={onCopied}
-      {...props}
-    />
+  const Button: FC<{ className?: string }> = ({ className, ...props }) => (
+    <div className={clsx('w-fit h-fit bg-inherit', className)} {...props}>
+      <CopyToClipboardButton
+        textToCopy={getNodeText(children)}
+        tooltipColor={tooltipColor ?? filenameColor}
+        onCopied={onCopied}
+      />
+    </div>
   );
 
   return (


### PR DESCRIPTION
<img width="284" alt="image" src="https://github.com/mintlify/components/assets/20213114/e3d87126-220e-45bb-9363-4f067ebab3e4">

<img width="94" alt="image" src="https://github.com/mintlify/components/assets/20213114/1492b041-7c22-436a-a258-e6c4eacc0a8c">


I believe the user was explicitly setting the content to `nowrap` which is probably not optimized for this component. There's still the side effect of partially covering the text, but I didn't want to change too much and possibly break things visually since I don't have enough context/time.

