### PR TITLE
fix(accordion): remove unintended clipboard copy on open

### DIFF
--- a/packages/components/src/components/accordion/accordion-url-utils.ts
+++ b/packages/components/src/components/accordion/accordion-url-utils.ts
@@ -1,5 +1,4 @@
 import isEqual from "lodash/isEqual";
-import { copyToClipboard } from "@/utils/copy-to-clipboard";
 
 const CONNECTING_CHARACTER = ":";
 
@@ -41,8 +40,6 @@ const updateAndCopyUrl = () => {
 
     const idsString = ids.join(CONNECTING_CHARACTER);
     const newUrl = buildHistoryUrl(idsString);
-
-    copyToClipboard(newUrl);
 
     window.history.replaceState(
       { ...window.history.state, as: newUrl, url: newUrl },


### PR DESCRIPTION
## Summary

Fixes #27 (reported on [mintlify/mdx#27](https://github.com/mintlify/mdx/issues/27)).

Clicking an accordion to expand/collapse it was silently overwriting the user's clipboard with the current URL + hash fragment. This behavior was unexpected and disruptive — especially when the user had something else copied.

- Removed the `copyToClipboard(newUrl)` call in `updateAndCopy`
- Removed the now-unused `copyToClipboard` import
- The URL hash is still updated via `window.history.replaceState` so deep-linking to open accordions continues to work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes an unintended clipboard write during accordion URL management; behavior change is limited to client-side UX and should not affect data or security.
> 
> **Overview**
> Accordion URL management no longer copies the generated deep-link URL into the user’s clipboard when sections are opened/closed.
> 
> The unused `copyToClipboard` import is removed, and URL updates continue to happen via `window.history.replaceState` so hash-based deep linking still works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dbca8c84db2263da3ddbb1c7ffe164a3836ce2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->