### PR TITLE
fix(code-group): add TOML language preset to fix missing icon

### DIFF
--- a/packages/components/src/utils/shiki/snippet-presets.ts
+++ b/packages/components/src/utils/shiki/snippet-presets.ts
@@ -10,7 +10,7 @@ type SnippetPreset = {
   /** Shiki language for syntax highlighting */
   shikiLanguage: string;
   /** httpsnippet config for code generation */
-  httpSnippet: {
+  httpSnippet?: {
     target: string;
     client?: string;
   };
@@ -144,6 +144,11 @@ const SNIPPET_PRESETS: SnippetPreset[] = [
     displayName: "Dart",
     shikiLanguage: "dart",
     httpSnippet: { target: "dart" },
+  },
+  {
+    key: "toml",
+    displayName: "TOML",
+    shikiLanguage: "yaml",
   },
 ];
 


### PR DESCRIPTION
## Summary

Fixes [mintlify/mdx#40](https://github.com/mintlify/mdx/issues/40).

`<CodeGroup dropdown>` with a TOML code block was showing a YAML icon instead of a TOML icon. The root cause was that `SNIPPET_PRESETS` had no entry for `toml`, so `getIconKey("toml")` returned `undefined`, causing the icon lookup to fall back to the YAML devicon.

- Added a `toml` preset with `displayName: "TOML"` and `shikiLanguage: "yaml"` (consistent with the existing `SHIKI_LANG_MAP` which uses YAML grammar for TOML highlighting)
- Made `httpSnippet` optional in `SnippetPreset` since config/data formats like TOML don't have an HTTP snippet target

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small config/type change that only affects language preset lookup and optional handling of `httpSnippet` for non-HTTP formats.
> 
> **Overview**
> Fixes missing TOML language handling in code-group/snippet preset resolution by adding a `toml` entry (with `displayName: "TOML"` and YAML-based Shiki highlighting) so icon lookup can return a TOML devicon instead of falling back.
> 
> Updates the `SnippetPreset` type to make `httpSnippet` optional, allowing data/config formats like TOML to exist without an HTTP snippet generation target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f6c63c0a5f1c43e32034a6105b44d25b8cd8434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->