### PR TITLE
fix(packages/components/src): MDX indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.17] - 2026-05-01
+
+### Fixed
+
+- Added TOML language preset to CodeGroup to fix missing icon (#235 by @20syldev)
+- Removed unintended clipboard copy on Accordion open (#234 by @20syldev)
+
 ## [1.0.16] - 2026-04-17
 
 ### Changed

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/components",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Mintlify open-source UI components",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/components/src/components/accordion/accordion-url-utils.ts
+++ b/packages/components/src/components/accordion/accordion-url-utils.ts
@@ -1,5 +1,4 @@
 import isEqual from "lodash/isEqual";
-import { copyToClipboard } from "@/utils/copy-to-clipboard";
 
 const CONNECTING_CHARACTER = ":";
 
@@ -41,8 +40,6 @@ const updateAndCopyUrl = () => {
 
     const idsString = ids.join(CONNECTING_CHARACTER);
     const newUrl = buildHistoryUrl(idsString);
-
-    copyToClipboard(newUrl);
 
     window.history.replaceState(
       { ...window.history.state, as: newUrl, url: newUrl },

--- a/packages/components/src/components/code-block/code-block.stories.tsx
+++ b/packages/components/src/components/code-block/code-block.stories.tsx
@@ -464,3 +464,43 @@ export const WithCustomClassName: Story = {
     </CodeBlock>
   ),
 };
+
+export const MDXIndents: Story = {
+  render: () => (
+    <CodeBlock filename="example.ts" language="ts">
+      {`import {
+        a,
+        b,
+      } from 'pkg';
+
+      async function main() {
+        console.log('hello');
+      }`}
+    </CodeBlock>
+  ),
+};
+
+export const MDXIndentsDeeplyNested: Story = {
+  render: () => (
+    <CodeBlock filename="nested.ts" language="ts">
+      {`function outer() {
+        function middle() {
+          function inner() {
+            function deepest() {
+              if (true) {
+                for (let i = 0; i < 10; i++) {
+                  while (i > 0) {
+                    return 42;
+                  }
+                }
+              }
+            }
+            return deepest();
+          }
+          return inner();
+        }
+        return middle();
+      }`}
+    </CodeBlock>
+  ),
+};

--- a/packages/components/src/components/code-block/code-block.tsx
+++ b/packages/components/src/components/code-block/code-block.tsx
@@ -2,8 +2,8 @@ import type { ReactNode, RefObject } from "react";
 
 import { Classes } from "@/constants/selectors";
 import { cn } from "@/utils/cn";
-import { getNodeText } from "@/utils/get-node-text";
 import type { CodeBlockTheme, CodeStyling } from "@/utils/shiki/code-styling";
+import { getCodeString } from "@/utils/shiki/lib";
 
 import { BaseCodeBlock } from "./base-code-block";
 import { CodeHeader } from "./code-header";
@@ -98,7 +98,7 @@ const CodeBlock = function CodeBlock(params: CodeBlockProps) {
     copyButtonProps,
   } = params;
 
-  const codeString = getNodeText(children);
+  const codeString = getCodeString(children, className, true);
   const hasGrayBackgroundContainer = !!filename || !!icon;
 
   return (

--- a/packages/components/src/components/code-group/code-group.tsx
+++ b/packages/components/src/components/code-group/code-group.tsx
@@ -18,8 +18,8 @@ import {
 import { Icon as ComponentIcon } from "@/components/icon";
 import { Classes } from "@/constants/selectors";
 import { cn } from "@/utils/cn";
-import { getNodeText } from "@/utils/get-node-text";
 import type { CodeBlockTheme, CodeStyling } from "@/utils/shiki/code-styling";
+import { getCodeString } from "@/utils/shiki/lib";
 
 import { LanguageDropdown } from "./language-dropdown";
 
@@ -220,7 +220,11 @@ const CodeGroup = ({
           {feedbackButton && feedbackButton}
           <CopyToClipboardButton
             codeBlockTheme={codeBlockTheme}
-            textToCopy={getNodeText(childArr[selectedIndex]?.props?.children)}
+            textToCopy={getCodeString(
+              childArr[selectedIndex]?.props?.children,
+              childArr[selectedIndex]?.props?.className,
+              true
+            )}
             {...copyButtonProps}
           />
           {askAiButton && askAiButton}

--- a/packages/components/src/utils/shiki/lib.ts
+++ b/packages/components/src/utils/shiki/lib.ts
@@ -4,6 +4,12 @@ import { getNodeText } from "@/utils/get-node-text";
 import { SHIKI_CLASSNAME } from "@/utils/shiki/constants";
 
 const lineIndentRegex = /^( *)/;
+const closingStructureRegex = /^([}\])]|<\/)/;
+
+function getIndent(line: string): number {
+  const match = line.match(lineIndentRegex);
+  return match ? match[1].length : 0;
+}
 
 function findShikiClassName(children: unknown): boolean {
   if (!children || typeof children !== "object") {
@@ -45,26 +51,41 @@ function dedentCode(code: string): string {
     return code;
   }
 
-  const relevantLines = lines.slice(1).filter((line) => line.trim() !== "");
+  const relevantLines = lines.filter((line) => line.trim() !== "");
   if (relevantLines.length === 0) {
     return code;
   }
 
-  const minIndent = Math.min(
-    ...relevantLines.map((line) => {
-      const match = line.match(lineIndentRegex);
-      return match ? match[1].length : 0;
-    })
-  );
+  const firstLine = relevantLines[0];
+  const lastLine = relevantLines.at(-1) ?? firstLine;
+  const firstIndent = getIndent(firstLine);
+  const lastIndent = getIndent(lastLine);
+  const isTemplatePolluted =
+    firstIndent < lastIndent && closingStructureRegex.test(lastLine.trim());
 
+  if (isTemplatePolluted) {
+    const firstNonEmptyIndex = lines.findIndex((line) => line.trim() !== "");
+    const tail = relevantLines.slice(1);
+    if (tail.length === 0) {
+      return code;
+    }
+    const minIndent = Math.min(...tail.map(getIndent));
+    if (minIndent === 0) {
+      return code;
+    }
+    return lines
+      .map((line, i) =>
+        i <= firstNonEmptyIndex ? line : line.slice(minIndent)
+      )
+      .join("\n");
+  }
+
+  const minIndent = Math.min(...relevantLines.map(getIndent));
   if (minIndent === 0) {
     return code;
   }
 
-  return [
-    lines[0],
-    ...lines.slice(1).map((line) => line.slice(minIndent)),
-  ].join("\n");
+  return lines.map((line) => line.slice(minIndent)).join("\n");
 }
 
 function getCodeString(

--- a/packages/components/src/utils/shiki/lib.ts
+++ b/packages/components/src/utils/shiki/lib.ts
@@ -3,6 +3,8 @@ import { type ReactNode, useMemo } from "react";
 import { getNodeText } from "@/utils/get-node-text";
 import { SHIKI_CLASSNAME } from "@/utils/shiki/constants";
 
+const lineIndentRegex = /^( *)/;
+
 function findShikiClassName(children: unknown): boolean {
   if (!children || typeof children !== "object") {
     return false;
@@ -37,6 +39,34 @@ function findShikiClassName(children: unknown): boolean {
   return false;
 }
 
+function dedentCode(code: string): string {
+  const lines = code.split("\n");
+  if (lines.length <= 1) {
+    return code;
+  }
+
+  const relevantLines = lines.slice(1).filter((line) => line.trim() !== "");
+  if (relevantLines.length === 0) {
+    return code;
+  }
+
+  const minIndent = Math.min(
+    ...relevantLines.map((line) => {
+      const match = line.match(lineIndentRegex);
+      return match ? match[1].length : 0;
+    })
+  );
+
+  if (minIndent === 0) {
+    return code;
+  }
+
+  return [
+    lines[0],
+    ...lines.slice(1).map((line) => line.slice(minIndent)),
+  ].join("\n");
+}
+
 function getCodeString(
   children: ReactNode,
   className?: string,
@@ -50,7 +80,7 @@ function getCodeString(
 
   const codeString = getNodeText(children);
 
-  return codeString;
+  return dedentCode(codeString);
 }
 
 function calculateCodeLinesFromHtml(html: string | undefined): number {

--- a/packages/components/src/utils/shiki/snippet-presets.ts
+++ b/packages/components/src/utils/shiki/snippet-presets.ts
@@ -10,7 +10,7 @@ type SnippetPreset = {
   /** Shiki language for syntax highlighting */
   shikiLanguage: string;
   /** httpsnippet config for code generation */
-  httpSnippet: {
+  httpSnippet?: {
     target: string;
     client?: string;
   };
@@ -144,6 +144,11 @@ const SNIPPET_PRESETS: SnippetPreset[] = [
     displayName: "Dart",
     shikiLanguage: "dart",
     httpSnippet: { target: "dart" },
+  },
+  {
+    key: "toml",
+    displayName: "TOML",
+    shikiLanguage: "yaml",
   },
 ];
 


### PR DESCRIPTION
Issue: https://github.com/mintlify/components/issues/226

## Summary

When CodeBlock is used inside MDX/JSX with template literals, the code content inherits the surrounding JSX indentation, causing it to render with extra leading whitespace. This fix adds a dedentCode utility that detects the minimum indentation across all non-empty lines (after the first) and strips it uniformly, so the rendered code aligns correctly regardless of nesting depth.

Two Storybook stories (MDXIndents, MDXIndentsDeeplyNested) are added to cover typical and deeply-nested JSX indentation scenarios.

**MDXIndents**

<img width="800" height="524" alt="MDX_Indents" src="https://github.com/user-attachments/assets/da519925-cc8e-40f5-87f2-d0ab6fb4f13b" />


**MDXIndentsDeeplyNested**

<img width="800" height="598" alt="MDX_IndentsDeeplyNested" src="https://github.com/user-attachments/assets/58511d55-043f-439c-95da-eec189389529" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core code rendering/extraction used by `CodeBlock`/`CodeGroup` (whitespace normalization affects both display and copied text), which could subtly change formatting in existing docs. Other changes are minor (removing an unintended clipboard side effect and adding a TOML preset).
> 
> **Overview**
> Fixes MDX/JSX template-literal indentation issues by routing `CodeBlock`/`CodeGroup` text extraction through `getCodeString` and adding a `dedentCode` step in `utils/shiki/lib.ts`, so leading whitespace from surrounding JSX nesting is stripped consistently (including for copy-to-clipboard).
> 
> Removes the side effect that copied the updated URL to the clipboard when an `Accordion` opens, and adds a `toml` snippet preset (with optional `httpSnippet`) to restore a missing language/icon. Also bumps `@mintlify/components` to `1.0.17` and updates the changelog, plus adds two Storybook stories covering MDX indentation scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91e5341293fafeca62d5518086b997411cd12ee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->