### PR TITLE
export badge configs

### DIFF
--- a/packages/components/src/components/badge/badge.tsx
+++ b/packages/components/src/components/badge/badge.tsx
@@ -3,21 +3,27 @@ import { Icon } from "@/components/icon";
 import { cn } from "@/utils/cn";
 import type { IconLibrary, IconType } from "@/utils/icon-utils";
 
-type BadgeSize = "xs" | "sm" | "md" | "lg";
-type BadgeShape = "rounded" | "pill";
-type BadgeVariant = "solid" | "outline";
-type BadgeColor =
-  | "gray"
-  | "blue"
-  | "green"
-  | "orange"
-  | "yellow"
-  | "red"
-  | "purple"
-  | "white"
-  | "surface"
-  | "white-destructive"
-  | "surface-destructive";
+const BADGE_COLORS = [
+  "gray",
+  "blue",
+  "green",
+  "orange",
+  "yellow",
+  "red",
+  "purple",
+  "white",
+  "surface",
+  "white-destructive",
+  "surface-destructive",
+] as const;
+const BADGE_SHAPES = ["rounded", "pill"] as const;
+const BADGE_SIZES = ["xs", "sm", "md", "lg"] as const;
+const BADGE_VARIANTS = ["solid", "outline"] as const;
+
+type BadgeSize = (typeof BADGE_SIZES)[number];
+type BadgeShape = (typeof BADGE_SHAPES)[number];
+type BadgeVariant = (typeof BADGE_VARIANTS)[number];
+type BadgeColor = (typeof BADGE_COLORS)[number];
 
 const sizeVariants: Record<BadgeSize, string> = {
   lg: 'gap-1 py-1 pl-2.5 pr-2.5 [&_svg]:size-3.5 text-sm tracking-[-0.1px] data-[shape="rounded"]:rounded-[8px]',
@@ -170,5 +176,13 @@ const Badge = ({
   return <span {...commonProps}>{content}</span>;
 };
 
-export { Badge };
+export {
+  Badge,
+  BADGE_COLORS,
+  BADGE_SHAPES,
+  BADGE_SIZES,
+  BADGE_VARIANTS,
+  colorVariants,
+  sizeVariants,
+};
 export type { BadgeSize, BadgeProps, BadgeShape, BadgeVariant, BadgeColor };

--- a/packages/components/src/components/badge/index.ts
+++ b/packages/components/src/components/badge/index.ts
@@ -1,2 +1,16 @@
-export type { BadgeColor, BadgeProps, BadgeShape, BadgeSize } from "./badge";
-export { Badge } from "./badge";
+export type {
+  BadgeColor,
+  BadgeProps,
+  BadgeShape,
+  BadgeSize,
+  BadgeVariant,
+} from "./badge";
+export {
+  BADGE_COLORS,
+  BADGE_SHAPES,
+  BADGE_SIZES,
+  BADGE_VARIANTS,
+  Badge,
+  colorVariants,
+  sizeVariants,
+} from "./badge";


### PR DESCRIPTION
## Summary
Update badge configs

## Test Plan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer export and typing refactor only; no behavior change to Badge rendering.
> 
> **Overview**
> **Badge** option unions are now driven by shared `as const` lists (`BADGE_COLORS`, `BADGE_SHAPES`, `BADGE_SIZES`, `BADGE_VARIANTS`) instead of inline string unions, so runtime values and TypeScript types stay aligned.
> 
> The package **public API** grows: those constants plus `colorVariants` and `sizeVariants` are re-exported from `badge` and the barrel `index`, and **`BadgeVariant`** is included in the type exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a9a7c53d73a33f4cd8f588e9de78e3167b963af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->