### PR TITLE
fix: CodeBlock mis-indents string children

### DIFF
--- a/packages/components/src/components/code-block/code-block.tsx
+++ b/packages/components/src/components/code-block/code-block.tsx
@@ -2,8 +2,8 @@ import type { ReactNode, RefObject } from "react";
 
 import { Classes } from "@/constants/selectors";
 import { cn } from "@/utils/cn";
-import { getNodeText } from "@/utils/get-node-text";
 import type { CodeBlockTheme, CodeStyling } from "@/utils/shiki/code-styling";
+import { getCodeString } from "@/utils/shiki/lib";
 
 import { BaseCodeBlock } from "./base-code-block";
 import { CodeHeader } from "./code-header";
@@ -98,7 +98,7 @@ const CodeBlock = function CodeBlock(params: CodeBlockProps) {
     copyButtonProps,
   } = params;
 
-  const codeString = getNodeText(children);
+  const codeString = getCodeString(children, className, true);
   const hasGrayBackgroundContainer = !!filename || !!icon;
 
   return (

--- a/packages/components/src/components/code-group/code-group.tsx
+++ b/packages/components/src/components/code-group/code-group.tsx
@@ -18,8 +18,8 @@ import {
 import { Icon as ComponentIcon } from "@/components/icon";
 import { Classes } from "@/constants/selectors";
 import { cn } from "@/utils/cn";
-import { getNodeText } from "@/utils/get-node-text";
 import type { CodeBlockTheme, CodeStyling } from "@/utils/shiki/code-styling";
+import { getCodeString } from "@/utils/shiki/lib";
 
 import { LanguageDropdown } from "./language-dropdown";
 
@@ -220,7 +220,11 @@ const CodeGroup = ({
           {feedbackButton && feedbackButton}
           <CopyToClipboardButton
             codeBlockTheme={codeBlockTheme}
-            textToCopy={getNodeText(childArr[selectedIndex]?.props?.children)}
+            textToCopy={getCodeString(
+              childArr[selectedIndex]?.props?.children,
+              childArr[selectedIndex]?.props?.className,
+              true
+            )}
             {...copyButtonProps}
           />
           {askAiButton && askAiButton}

--- a/packages/components/src/utils/dedent.ts
+++ b/packages/components/src/utils/dedent.ts
@@ -1,0 +1,137 @@
+// Strips the indentation that leaks in from surrounding JSX/MDX when code is
+// passed to a code block as a template literal, e.g.
+//
+//   <CodeBlock>
+//     {`import {
+//       a,
+//     } from 'pkg';`}
+//   </CodeBlock>
+//
+// In a template literal the first line sits flush against the opening backtick
+// while every continuation line carries the JSX indentation. We therefore
+// compute the shared indent from the continuation lines only (ignoring blank
+// lines) and strip it from them, leaving the first line as-is. Leading and
+// trailing blank lines are trimmed.
+//
+// This is a no-op for correctly-formatted code, which always has at least one
+// continuation line back at the base column (a closing brace, a top-level
+// statement, etc.), making the shared continuation indent 0. Only blocks where
+// every continuation line is indented — the JSX-pollution signature — are
+// changed. Indentation is measured in spaces to avoid corrupting mixed
+// tab/space input.
+//
+// Limitation: when the first line is flush against the backtick AND is itself a
+// parent of indentation-significant content (e.g. a top-level yaml key whose
+// children never return to column 0), the intended first level of nesting is
+// indistinguishable from JSX pollution and gets stripped. For such content,
+// author with a leading newline so every line carries the shared indent.
+//
+// Stories for manual verification — paste any of these into
+// code-block.stories.tsx and view in Storybook. Each should render with clean,
+// author-intended indentation (except the documented limitation case).
+//
+// // Issue #226: flush first line, brace-terminated continuation lines.
+// export const MDXStringChildrenIndentation: Story = {
+//   render: () => (
+//     <CodeBlock filename="example.ts" language="ts">
+//       {`import {
+//         a,
+//         b,
+//       } from 'pkg';
+//
+//       async function main() {
+//         console.log('hello');
+//       }`}
+//     </CodeBlock>
+//   ),
+// };
+//
+// // Leading-newline env vars (no closing bracket).
+// export const MDXStringChildrenLeadingNewline: Story = {
+//   render: () => (
+//     <CodeBlock language="bash">
+//       {`
+//         CLICKHOUSE_USERNAME=main
+//         CLICKHOUSE_FRAGMENT=
+//         CLICKHOUSE_IP=123.456.78.90
+//       `}
+//     </CodeBlock>
+//   ),
+// };
+//
+// // Leading-newline yaml — relative nesting is preserved.
+// export const MDXStringChildrenYaml: Story = {
+//   render: () => (
+//     <CodeBlock filename="app.yaml" language="yaml">
+//       {`
+//         applications:
+//           myapp:
+//             source:
+//               root: "/"
+//       `}
+//     </CodeBlock>
+//   ),
+// };
+//
+// // Deeply nested — the full indentation ladder is preserved.
+// export const MDXStringChildrenDeeplyNested: Story = {
+//   render: () => (
+//     <CodeBlock filename="nested.ts" language="ts">
+//       {`function outer() {
+//         function middle() {
+//           function inner() {
+//             return 42;
+//           }
+//           return inner();
+//         }
+//         return middle();
+//       }`}
+//     </CodeBlock>
+//   ),
+// };
+//
+// // Limitation: a flush first line that is itself a parent of
+// // indentation-significant content loses its first nesting level (myapp ends
+// // up flush with applications). Author with a leading newline (see the yaml
+// // story above) to avoid this.
+// export const MDXStringChildrenFlushParentLimitation: Story = {
+//   render: () => (
+//     <CodeBlock filename="app.yaml" language="yaml">
+//       {`applications:
+//         myapp:
+//           source:
+//             root: "/"`}
+//     </CodeBlock>
+//   ),
+// };
+const LEADING_SPACES_REGEX = /^[ ]*/;
+
+export function dedent(code: string): string {
+  const lines = code.split("\n");
+  if (lines.length <= 1) {
+    return code;
+  }
+
+  const continuationIndents = lines
+    .slice(1)
+    .filter((line) => line.trim() !== "")
+    .map((line) => line.match(LEADING_SPACES_REGEX)?.[0].length ?? 0);
+
+  const minIndent = continuationIndents.length
+    ? Math.min(...continuationIndents)
+    : 0;
+
+  const dedented =
+    minIndent > 0
+      ? lines.map((line, i) => (i === 0 ? line : line.slice(minIndent)))
+      : lines.slice();
+
+  while (dedented.length && dedented[0].trim() === "") {
+    dedented.shift();
+  }
+  while (dedented.length && dedented.at(-1)?.trim() === "") {
+    dedented.pop();
+  }
+
+  return dedented.join("\n");
+}

--- a/packages/components/src/utils/shiki/lib.ts
+++ b/packages/components/src/utils/shiki/lib.ts
@@ -1,5 +1,6 @@
 import { type ReactNode, useMemo } from "react";
 
+import { dedent } from "@/utils/dedent";
 import { getNodeText } from "@/utils/get-node-text";
 import { SHIKI_CLASSNAME } from "@/utils/shiki/constants";
 
@@ -50,7 +51,7 @@ function getCodeString(
 
   const codeString = getNodeText(children);
 
-  return codeString;
+  return dedent(codeString);
 }
 
 function calculateCodeLinesFromHtml(html: string | undefined): number {


### PR DESCRIPTION
## Summary

adds a robust dedent utility with storybook examples to fix the case reported in Issue #226 with CodeBlock string children mis-indented

## Test Plan

| | before      | after |
| ----------- | ----------- | ----------- |
| indentation | <img width="1248" height="520" alt="indentation--before" src="https://github.com/user-attachments/assets/2a380066-910e-4d7b-bc2c-40e4f6c0da46" /> |  <img width="1248" height="520" alt="indentation--after" src="https://github.com/user-attachments/assets/acfdee72-2c94-4b6a-ac49-ac9dc8bb50d1" /> |
| yaml | <img width="1248" height="328" alt="yaml--before" src="https://github.com/user-attachments/assets/fc83a04a-4953-4dc2-8e96-3294ec4604c1" /> | <img width="1248" height="328" alt="yaml--after" src="https://github.com/user-attachments/assets/a0b5c755-a0d3-4ebf-8cfb-3611c5922964" /> |
| leading newline |  <img width="1248" height="204" alt="leading-newline--before" src="https://github.com/user-attachments/assets/2d3e9583-4f56-462b-8c2b-61708d998317" /> | <img width="1248" height="204" alt="leading-newline--after" src="https://github.com/user-attachments/assets/7ef11c12-58da-4c24-a5ed-b0f871f49f10" />
| deeply nested | <img width="1248" height="568" alt="deeply-nested--before" src="https://github.com/user-attachments/assets/dcd37cf6-3298-4f6d-980a-e015c8a9815a" /> | <img width="1248" height="568" alt="deeply-nested--after" src="https://github.com/user-attachments/assets/9e7638f0-0b05-421d-b040-44b65403ad08" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All non-Shiki string children flow through new dedent logic for highlight and copy; edge-case YAML without a leading newline can change indentation.
> 
> **Overview**
> Fixes **Issue #226** where `CodeBlock` / `CodeGroup` string children (common in MDX/JSX template literals) picked up extra leading spaces from surrounding markup, so displayed and copied code looked wrongly indented.
> 
> Adds a **`dedent`** helper that strips the shared indent from continuation lines only (first line unchanged), trims leading/trailing blank lines, and leaves already-correct code unchanged when a line returns to column 0. **`getCodeString`** now runs extracted text through `dedent`; **`CodeBlock`** and **`CodeGroup`** use `getCodeString` (with `forceExtract` where needed) for copy-to-clipboard instead of raw **`getNodeText`**.
> 
> **Caveat:** YAML (or similar) with a flush first line and no line at column 0 can lose one nesting level; docs suggest a leading newline in the template literal for that pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f9c6e48c447ba906adbdd3f047f080cac3ee1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->