### PR TITLE
1.0.18 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.18] - 2026-07-01
+
+### Added
+
+- Exported Badge config constants (`BADGE_COLORS`, `BADGE_SHAPES`, `BADGE_SIZES`, `BADGE_VARIANTS`) and the `BadgeVariant` type (#241)
+
+### Fixed
+
+- Fixed CodeBlock mis-indenting string children (#245)
+
+### Changed
+
+- Bumped postcss from 8.5.6 to 8.5.10 (#238)
+- Bumped mermaid from 11.12.2 to 11.15.0 (#239)
+- Bumped js-yaml from 4.1.1 to 4.3.0 (#242)
+- Bumped vite from 6.4.2 to 6.4.3 (#244)
+
 ## [1.0.17] - 2026-05-01
 
 ### Fixed

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/components",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Mintlify open-source UI components",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release-metadata only in this diff (version and changelog); no application code changes.
> 
> **Overview**
> Cuts **1.0.18** of `@mintlify/components` by bumping `packages/components/package.json` from **1.0.17** to **1.0.18** and adding a **2026-07-01** changelog entry.
> 
> The release notes document work already landed on the branch: **Badge** public exports (`BADGE_COLORS`, `BADGE_SHAPES`, `BADGE_SIZES`, `BADGE_VARIANTS`, `BadgeVariant`), a **CodeBlock** fix for mis-indented string children, and dependency bumps for **postcss**, **mermaid**, **js-yaml**, and **vite**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af82dea58f398db37dca67e3b685aa9a8c2c1c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->