### PR TITLE
feat: add Mention component

### DIFF
--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -9,6 +9,7 @@ export * from "./columns";
 export * from "./expandable";
 export * from "./frame";
 export * from "./icon";
+export * from "./mention";
 export * from "./mermaid";
 export * from "./panel";
 export * from "./property";

--- a/packages/components/src/components/mention/index.ts
+++ b/packages/components/src/components/mention/index.ts
@@ -1,0 +1,2 @@
+export type { MentionColor, MentionProps } from "./mention";
+export { MENTION_COLORS, Mention, mentionColorVariants } from "./mention";

--- a/packages/components/src/components/mention/mention.stories.tsx
+++ b/packages/components/src/components/mention/mention.stories.tsx
@@ -9,9 +9,29 @@ const meta: Meta<typeof Mention> = {
   },
   tags: ["autodocs"],
   argTypes: {
+    children: {
+      control: "text",
+      description: "The display label shown inside the mention pill.",
+    },
+    path: {
+      control: "text",
+      description:
+        "Page path for a **page mention**. When set, the component renders as an `<a>` link and shows the page icon by default. Use either `path` or `user`, not both.",
+    },
+    user: {
+      control: "text",
+      description:
+        "Username or identifier for a **user mention**. When set, the component shows the person icon by default. Use either `path` or `user`, not both.",
+    },
+    icon: {
+      control: "text",
+      description:
+        "Optional icon override. Accepts a **FontAwesome or Lucide icon name** (e.g. `plane`, `bed`, `circle-check`), an **image URL** rendered as a circular avatar, or any **React node** for fully custom icon content. Omit to use the default page or person icon.",
+    },
     color: {
       control: "select",
       options: ["neutral", "info", "success", "warning", "feature", "error"],
+      description: "Color variant. Defaults to `neutral`.",
     },
     iconType: {
       control: "select",
@@ -23,17 +43,31 @@ const meta: Meta<typeof Mention> = {
         "thin",
         "brands",
         "sharp-solid",
+        "sharp-light",
+        "sharp-regular",
+        "sharp-thin",
+        "sharp-duotone-solid",
       ],
+      description:
+        "FontAwesome icon style. Only applies when `icon` is a string icon name and `iconLibrary` is `fontawesome`. Defaults to `regular`.",
     },
     iconLibrary: {
       control: "select",
       options: ["fontawesome", "lucide"],
+      description:
+        "Icon library used to resolve the `icon` string. Defaults to `fontawesome`. Pass a React node to `icon` to bypass this entirely.",
     },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Mention>;
+
+// ─── Interactive playground ─────────────────────────────────────────────────
+// Use the Controls panel (below) to experiment with every prop.
+// • Set `path` for a page mention, `user` for a user mention (not both).
+// • `icon` accepts a FontAwesome name (e.g. "plane"), a Lucide name with
+//   iconLibrary="lucide", or a full image URL for an avatar.
 
 export const Default: Story = {
   args: {

--- a/packages/components/src/components/mention/mention.stories.tsx
+++ b/packages/components/src/components/mention/mention.stories.tsx
@@ -273,6 +273,59 @@ export const LucideIcons: Story = {
   ),
 };
 
+// ─── Wrapping ───────────────────────────────────────────────────────────────
+
+export const LongLabelWrapping: Story = {
+  name: "Long label (wrapping)",
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div>
+        <p className="mb-3 text-stone-400 text-xs uppercase tracking-wide">
+          Natural wrap inside a narrow container
+        </p>
+        <div className="w-36">
+          <Mention color="info" icon="bed" path="/accommodation">
+            Accommodation &amp; Meals Planning Guide
+          </Mention>
+        </div>
+      </div>
+
+      <div>
+        <p className="mb-3 text-stone-400 text-xs uppercase tracking-wide">
+          Forced line break via &lt;br /&gt;
+        </p>
+        <div className="flex flex-col gap-2">
+          <Mention color="feature" path="/page">
+            Q4 Product Roadmap
+            <br />
+            Planning &amp; Review
+          </Mention>
+          <Mention color="success" icon="leaf" path="/sustainability">
+            Sustainability
+            <br />
+            Guidelines
+          </Mention>
+        </div>
+      </div>
+
+      <div>
+        <p className="mb-3 text-stone-400 text-xs uppercase tracking-wide">
+          Inline in prose with wrapping label
+        </p>
+        <p className="max-w-xs text-sm text-stone-700">
+          Please review the{" "}
+          <Mention color="info" icon="file-lines" path="/compliance">
+            Compliance &amp; Legal
+            <br />
+            Documentation
+          </Mention>{" "}
+          before proceeding.
+        </p>
+      </div>
+    </div>
+  ),
+};
+
 // ─── All badge variants (design reference) ──────────────────────────────────
 
 export const DesignReference: Story = {

--- a/packages/components/src/components/mention/mention.stories.tsx
+++ b/packages/components/src/components/mention/mention.stories.tsx
@@ -1,0 +1,300 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Mention } from "./mention";
+
+const meta: Meta<typeof Mention> = {
+  title: "Components/Mention",
+  component: Mention,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    color: {
+      control: "select",
+      options: ["neutral", "info", "success", "warning", "feature", "error"],
+    },
+    iconType: {
+      control: "select",
+      options: [
+        "regular",
+        "solid",
+        "light",
+        "duotone",
+        "thin",
+        "brands",
+        "sharp-solid",
+      ],
+    },
+    iconLibrary: {
+      control: "select",
+      options: ["fontawesome", "lucide"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Mention>;
+
+export const Default: Story = {
+  args: {
+    children: "Getting Started",
+    path: "/getting-started",
+    color: "neutral",
+  },
+};
+
+// ─── Page mentions ─────────────────────────────────────────────────────────
+
+export const PageMention: Story = {
+  name: "Page mention (default icon)",
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Mention path="/getting-started">Getting Started</Mention>
+      <Mention path="/api-reference">API Reference</Mention>
+      <Mention path="/changelog">Changelog</Mention>
+    </div>
+  ),
+};
+
+export const PageMentionCustomIcon: Story = {
+  name: "Page mention (custom icon)",
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Mention color="info" icon="plane" path="/travel">
+        Travel
+      </Mention>
+      <Mention color="info" icon="bed" path="/accommodation">
+        Accommodation &amp; Meals
+      </Mention>
+      <Mention color="success" icon="leaf" path="/sustainability">
+        Sustainability
+      </Mention>
+      <Mention color="warning" icon="triangle-exclamation" path="/warnings">
+        Warnings
+      </Mention>
+    </div>
+  ),
+};
+
+// ─── User mentions ──────────────────────────────────────────────────────────
+
+export const UserMention: Story = {
+  name: "User mention (default icon)",
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Mention color="info" user="james-baduor">
+        James Baduor
+      </Mention>
+      <Mention user="alex-chen">Alex Chen</Mention>
+      <Mention color="feature" user="sara-kim">
+        Sara Kim
+      </Mention>
+    </div>
+  ),
+};
+
+export const UserMentionWithAvatar: Story = {
+  name: "User mention (avatar URL)",
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Mention
+        color="info"
+        icon="https://api.dicebear.com/7.x/avataaars/svg?seed=james"
+        user="james-baduor"
+      >
+        James Baduor
+      </Mention>
+      <Mention
+        color="neutral"
+        icon="https://api.dicebear.com/7.x/avataaars/svg?seed=alex"
+        user="alex-chen"
+      >
+        Alex Chen
+      </Mention>
+    </div>
+  ),
+};
+
+// ─── Color variants ─────────────────────────────────────────────────────────
+
+export const Colors: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Mention color="neutral" path="/page">
+        Neutral
+      </Mention>
+      <Mention color="info" path="/page">
+        Info
+      </Mention>
+      <Mention color="success" path="/page">
+        Success
+      </Mention>
+      <Mention color="warning" path="/page">
+        Warning
+      </Mention>
+      <Mention color="feature" path="/page">
+        Feature
+      </Mention>
+      <Mention color="error" path="/page">
+        Error
+      </Mention>
+    </div>
+  ),
+};
+
+export const ColorsWithUser: Story = {
+  name: "Colors (user mentions)",
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Mention color="neutral" user="person">
+        Neutral
+      </Mention>
+      <Mention color="info" user="person">
+        Info
+      </Mention>
+      <Mention color="success" user="person">
+        Success
+      </Mention>
+      <Mention color="warning" user="person">
+        Warning
+      </Mention>
+      <Mention color="feature" user="person">
+        Feature
+      </Mention>
+      <Mention color="error" user="person">
+        Error
+      </Mention>
+    </div>
+  ),
+};
+
+// ─── In-context usage ───────────────────────────────────────────────────────
+
+export const InlineInProse: Story = {
+  name: "Inline in prose (checklist context)",
+  render: () => (
+    <div className="max-w-md space-y-3 font-sans text-sm text-stone-800">
+      <label className="flex items-start gap-2">
+        <input
+          checked
+          className="mt-0.5 accent-green-600"
+          readOnly
+          type="checkbox"
+        />
+        <span>
+          Help us plan the activities in{" "}
+          <Mention color="info" icon="plane" path="/travel">
+            Travel
+          </Mention>{" "}
+          and party for the team
+        </span>
+      </label>
+      <label className="flex items-start gap-2">
+        <input
+          checked
+          className="mt-0.5 accent-green-600"
+          readOnly
+          type="checkbox"
+        />
+        <span>Book your trip and reserve a rental car</span>
+      </label>
+      <label className="flex items-start gap-2">
+        <input className="mt-0.5" readOnly type="checkbox" />
+        <span>
+          Fill the surveys on meals &rarr;{" "}
+          <Mention color="info" icon="bed" path="/accommodation">
+            Accommodation &amp; Meals
+          </Mention>
+        </span>
+      </label>
+      <label className="flex items-start gap-2">
+        <input className="mt-0.5" readOnly type="checkbox" />
+        <span>
+          Enter report details for further assessment &rarr;{" "}
+          <Mention color="info" user="james-baduor">
+            James Baduor
+          </Mention>
+        </span>
+      </label>
+    </div>
+  ),
+};
+
+// ─── Icon library ───────────────────────────────────────────────────────────
+
+export const LucideIcons: Story = {
+  name: "Lucide icon library",
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Mention color="info" icon="map" iconLibrary="lucide" path="/travel">
+        Travel
+      </Mention>
+      <Mention color="success" icon="leaf" iconLibrary="lucide" path="/eco">
+        Eco
+      </Mention>
+      <Mention color="feature" icon="sparkles" iconLibrary="lucide" path="/new">
+        New
+      </Mention>
+    </div>
+  ),
+};
+
+// ─── All badge variants (design reference) ──────────────────────────────────
+
+export const DesignReference: Story = {
+  name: "Design reference — all variants",
+  render: () => (
+    <div className="space-y-4">
+      <div>
+        <p className="mb-2 text-stone-400 text-xs uppercase tracking-wide">
+          Page mentions
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <Mention color="info" path="/page">
+            Page
+          </Mention>
+          <Mention color="success" path="/page">
+            Page
+          </Mention>
+          <Mention color="warning" path="/page">
+            Page
+          </Mention>
+          <Mention color="feature" path="/page">
+            Page
+          </Mention>
+          <Mention color="error" path="/page">
+            Page
+          </Mention>
+          <Mention color="neutral" path="/page">
+            Page
+          </Mention>
+        </div>
+      </div>
+      <div>
+        <p className="mb-2 text-stone-400 text-xs uppercase tracking-wide">
+          Person mentions
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <Mention color="info" user="person">
+            Person
+          </Mention>
+          <Mention color="success" user="person">
+            Person
+          </Mention>
+          <Mention color="warning" user="person">
+            Person
+          </Mention>
+          <Mention color="feature" user="person">
+            Person
+          </Mention>
+          <Mention color="error" user="person">
+            Person
+          </Mention>
+          <Mention color="neutral" user="person">
+            Person
+          </Mention>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/components/src/components/mention/mention.stories.tsx
+++ b/packages/components/src/components/mention/mention.stories.tsx
@@ -218,27 +218,82 @@ export const ColorsWithUser: Story = {
 export const Sizes: Story = {
   name: "Sizes",
   render: () => (
-    <div className="flex flex-col gap-3 text-stone-700">
-      <p className="text-xs">
-        Extra small — refer to <Mention path="/docs">Documentation</Mention> or
-        ask <Mention user="alex">Alex Chen</Mention>
-      </p>
-      <p className="text-sm">
-        Small — refer to <Mention path="/docs">Documentation</Mention> or ask{" "}
-        <Mention user="alex">Alex Chen</Mention>
-      </p>
-      <p className="text-base">
-        Base — refer to <Mention path="/docs">Documentation</Mention> or ask{" "}
-        <Mention user="alex">Alex Chen</Mention>
-      </p>
-      <p className="text-lg">
-        Large — refer to <Mention path="/docs">Documentation</Mention> or ask{" "}
-        <Mention user="alex">Alex Chen</Mention>
-      </p>
-      <p className="text-xl">
-        Extra large — refer to <Mention path="/docs">Documentation</Mention> or
-        ask <Mention user="alex">Alex Chen</Mention>
-      </p>
+    <div className="flex flex-col gap-4 text-stone-700">
+      <div className="flex flex-col gap-1 rounded-lg bg-gray-50 p-1">
+        <div className="py-px pl-0.5 text-right">
+          extra small <code className="bg-none p-0 font-bold">text-xs</code>
+        </div>
+        <p className="rounded-lg bg-white p-3 text-xs">
+          refer to{" "}
+          <Mention color="success" path="/docs">
+            Documentation
+          </Mention>{" "}
+          or ask{" "}
+          <Mention color="success" user="alex">
+            Alex Chen
+          </Mention>
+        </p>
+      </div>
+      <div className="flex flex-col gap-1 rounded-lg bg-gray-50 p-1">
+        <div className="py-px pl-0.5 text-right">
+          small <code className="bg-none p-0 font-bold">text-sm</code>
+        </div>
+        <p className="rounded-lg bg-white p-3 text-sm">
+          refer to{" "}
+          <Mention color="success" path="/docs">
+            Documentation
+          </Mention>{" "}
+          or ask{" "}
+          <Mention color="success" user="alex">
+            Alex Chen
+          </Mention>
+        </p>
+      </div>
+      <div className="flex flex-col gap-1 rounded-lg bg-gray-50 p-1">
+        <div className="py-px pl-0.5 text-right">
+          base <code className="bg-none p-0 font-bold">text-base</code>
+        </div>
+        <p className="rounded-lg bg-white p-3 text-base">
+          refer to{" "}
+          <Mention color="success" path="/docs">
+            Documentation
+          </Mention>{" "}
+          or ask{" "}
+          <Mention color="success" user="alex">
+            Alex Chen
+          </Mention>
+        </p>
+      </div>
+      <div className="flex flex-col gap-1 rounded-lg bg-gray-50 p-1">
+        <div className="py-px pl-0.5 text-right">
+          large <code className="bg-none p-0 font-bold">text-lg</code>
+        </div>
+        <p className="rounded-lg bg-white p-3 text-lg">
+          refer to{" "}
+          <Mention color="success" path="/docs">
+            Documentation
+          </Mention>{" "}
+          or ask{" "}
+          <Mention color="success" user="alex">
+            Alex Chen
+          </Mention>
+        </p>
+      </div>
+      <div className="flex flex-col gap-1 rounded-lg bg-gray-50 p-1">
+        <div className="py-px pl-0.5 text-right">
+          extra large <code className="bg-none p-0 font-bold">text-xl</code>
+        </div>
+        <p className="rounded-lg bg-white p-3 text-xl">
+          refer to{" "}
+          <Mention color="success" path="/docs">
+            Documentation
+          </Mention>{" "}
+          or ask{" "}
+          <Mention color="success" user="alex">
+            Alex Chen
+          </Mention>
+        </p>
+      </div>
     </div>
   ),
 };

--- a/packages/components/src/components/mention/mention.stories.tsx
+++ b/packages/components/src/components/mention/mention.stories.tsx
@@ -7,6 +7,15 @@ const meta: Meta<typeof Mention> = {
   parameters: {
     layout: "centered",
   },
+  // Wrap all stories in text-xs so existing story appearances are preserved now
+  // that the component inherits font-size from context rather than hardcoding it.
+  decorators: [
+    (Story) => (
+      <div className="text-xs">
+        <Story />
+      </div>
+    ),
+  ],
   tags: ["autodocs"],
   argTypes: {
     children: {
@@ -198,6 +207,38 @@ export const ColorsWithUser: Story = {
       <Mention color="error" user="person">
         Error
       </Mention>
+    </div>
+  ),
+};
+
+// ─── Sizes ──────────────────────────────────────────────────────────────────
+// Because every dimension (icon, padding, gap, radius) is expressed in em,
+// the component scales proportionally with whatever font-size surrounds it.
+
+export const Sizes: Story = {
+  name: "Sizes",
+  render: () => (
+    <div className="flex flex-col gap-3 text-stone-700">
+      <p className="text-xs">
+        Extra small — refer to <Mention path="/docs">Documentation</Mention> or
+        ask <Mention user="alex">Alex Chen</Mention>
+      </p>
+      <p className="text-sm">
+        Small — refer to <Mention path="/docs">Documentation</Mention> or ask{" "}
+        <Mention user="alex">Alex Chen</Mention>
+      </p>
+      <p className="text-base">
+        Base — refer to <Mention path="/docs">Documentation</Mention> or ask{" "}
+        <Mention user="alex">Alex Chen</Mention>
+      </p>
+      <p className="text-lg">
+        Large — refer to <Mention path="/docs">Documentation</Mention> or ask{" "}
+        <Mention user="alex">Alex Chen</Mention>
+      </p>
+      <p className="text-xl">
+        Extra large — refer to <Mention path="/docs">Documentation</Mention> or
+        ask <Mention user="alex">Alex Chen</Mention>
+      </p>
     </div>
   ),
 };

--- a/packages/components/src/components/mention/mention.tsx
+++ b/packages/components/src/components/mention/mention.tsx
@@ -1,0 +1,160 @@
+import type React from "react";
+import { Icon } from "@/components/icon";
+import { cn } from "@/utils/cn";
+import type { IconLibrary, IconType } from "@/utils/icon-utils";
+
+const MENTION_COLORS = [
+  "neutral",
+  "info",
+  "success",
+  "warning",
+  "feature",
+  "error",
+] as const;
+
+type MentionColor = (typeof MENTION_COLORS)[number];
+
+const colorVariants: Record<MentionColor, string> = {
+  neutral:
+    "[--mention-bg:#F5F5F4] dark:[--mention-bg:#292524] [--mention-text:#57534E] dark:[--mention-text:#A8A29E]",
+  info: "[--mention-bg:#EFF6FF] dark:[--mention-bg:#172554] [--mention-text:#1D4ED8] dark:[--mention-text:#93C5FD]",
+  success:
+    "[--mention-bg:#F0FDF4] dark:[--mention-bg:#052E16] [--mention-text:#15803D] dark:[--mention-text:#86EFAC]",
+  warning:
+    "[--mention-bg:#FFF7ED] dark:[--mention-bg:#431407] [--mention-text:#C2410C] dark:[--mention-text:#FDBA74]",
+  feature:
+    "[--mention-bg:#FAF5FF] dark:[--mention-bg:#3B0764] [--mention-text:#7E22CE] dark:[--mention-text:#D8B4FE]",
+  error:
+    "[--mention-bg:#FEF2F2] dark:[--mention-bg:#450A0A] [--mention-text:#B91C1C] dark:[--mention-text:#FCA5A5]",
+};
+
+type MentionProps = {
+  children: React.ReactNode;
+  /**
+   * Page path for a page mention. When provided, the component renders as an
+   * anchor tag linking to the page and displays the page icon by default.
+   */
+  path?: string;
+  /**
+   * Username or identifier for a user mention. When provided, the component
+   * displays the user icon by default.
+   */
+  user?: string;
+  /**
+   * Optional icon override. Accepts:
+   * - A FontAwesome or Lucide icon name string (e.g. `"plane"`, `"bed"`)
+   * - An image URL string, rendered as a circular avatar
+   * - Any React node for fully custom icon content
+   */
+  icon?: React.ReactNode | string;
+  /** Icon type for FontAwesome icons. */
+  iconType?: IconType;
+  /** Icon library to use. Defaults to `"fontawesome"`. */
+  iconLibrary?: IconLibrary;
+  /** Color variant. Defaults to `"neutral"`. */
+  color?: MentionColor;
+  className?: string;
+};
+
+const DEFAULT_PAGE_ICON = "file";
+const DEFAULT_USER_ICON = "circle-user";
+
+const isUrl = (s: string) =>
+  s.startsWith("http://") ||
+  s.startsWith("https://") ||
+  s.startsWith("/") ||
+  s.startsWith("data:");
+
+const ICON_NAME_REGEX = /^[\w-]+$/;
+const isIconName = (s: string) => ICON_NAME_REGEX.test(s);
+
+const Mention = ({
+  children,
+  path,
+  user,
+  icon,
+  iconType,
+  iconLibrary = "fontawesome",
+  color = "neutral",
+  className,
+}: MentionProps) => {
+  const isUser = !!user;
+  const defaultIconName = isUser ? DEFAULT_USER_ICON : DEFAULT_PAGE_ICON;
+  const resolvedIcon = icon ?? defaultIconName;
+
+  const renderIcon = () => {
+    if (typeof resolvedIcon !== "string") {
+      return (
+        <span aria-hidden="true" className="flex shrink-0 items-center">
+          {resolvedIcon}
+        </span>
+      );
+    }
+
+    if (isUrl(resolvedIcon)) {
+      return (
+        <img
+          alt=""
+          aria-hidden="true"
+          className="size-3 shrink-0 rounded-full object-cover"
+          height={12}
+          src={resolvedIcon}
+          width={12}
+        />
+      );
+    }
+
+    if (isIconName(resolvedIcon)) {
+      return (
+        <Icon
+          className="shrink-0"
+          icon={resolvedIcon}
+          iconLibrary={iconLibrary}
+          iconType={iconType}
+          overrideColor
+          overrideSize
+        />
+      );
+    }
+
+    // Emoji or other non-icon text
+    return (
+      <span aria-hidden="true" className="shrink-0 text-[0.8em] leading-none">
+        {resolvedIcon}
+      </span>
+    );
+  };
+
+  const isLink = !!path && !user;
+
+  const sharedClassName = cn(
+    "mention",
+    "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5",
+    "whitespace-nowrap font-medium text-xs leading-none",
+    "bg-(--mention-bg) text-(--mention-text)",
+    '[&_[data-component-part="icon-svg"]]:bg-(--mention-text)',
+    '[&_[data-component-part="icon-svg"]]:size-3',
+    colorVariants[color],
+    isLink && "cursor-pointer no-underline transition-opacity hover:opacity-80",
+    className
+  );
+
+  if (isLink) {
+    return (
+      <a className={sharedClassName} href={path}>
+        {renderIcon()}
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <span className={sharedClassName}>
+      {renderIcon()}
+      {children}
+    </span>
+  );
+};
+
+export { Mention, MENTION_COLORS, colorVariants as mentionColorVariants };
+export type { MentionProps, MentionColor };

--- a/packages/components/src/components/mention/mention.tsx
+++ b/packages/components/src/components/mention/mention.tsx
@@ -80,10 +80,17 @@ const Mention = ({
 }: MentionProps) => {
   const isUser = !!user;
   const defaultIconName = isUser ? DEFAULT_USER_ICON : DEFAULT_PAGE_ICON;
-  // Treat an empty string the same as omitted — fall back to the default icon.
-  const resolvedIcon = (icon === "" ? undefined : icon) ?? defaultIconName;
+  // null → explicitly hide the icon. "" → treat as omitted, fall back to default.
+  const hideIcon = icon === null;
+  const resolvedIcon = hideIcon
+    ? null
+    : ((icon === "" ? undefined : icon) ?? defaultIconName);
 
   const renderIcon = () => {
+    if (resolvedIcon === null) {
+      return null;
+    }
+
     if (typeof resolvedIcon !== "string") {
       return (
         <span aria-hidden="true" className="flex shrink-0 items-center">
@@ -128,9 +135,17 @@ const Mention = ({
 
   const isLink = !!path && !user;
 
+  // When an icon is present the left padding is tightened to match the vertical
+  // gap so the icon appears equally inset on all three sides (left, top, bottom).
+  // The right padding stays wider to give the label text room to breathe.
+  // When there is no icon both sides use the wider right padding value.
   const sharedClassName = cn(
     "mention",
-    "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5",
+    "inline-flex items-center gap-1 rounded-md py-0.5",
+    // Icon present: tight left padding so the icon is equally inset on all
+    // three sides (matches the 4px vertical gap). Right side stays wider.
+    // No icon: symmetric padding matching the right-side value.
+    resolvedIcon !== null ? "pr-2 pl-1" : "px-2",
     "font-medium text-xs",
     "bg-(--mention-bg) text-(--mention-text)",
     '[&_[data-component-part="icon-svg"]]:bg-(--mention-text)',

--- a/packages/components/src/components/mention/mention.tsx
+++ b/packages/components/src/components/mention/mention.tsx
@@ -130,8 +130,8 @@ const Mention = ({
 
   const sharedClassName = cn(
     "mention",
-    "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5",
-    "whitespace-nowrap font-medium text-xs leading-none",
+    "inline-flex items-center gap-1 rounded-md px-2 py-1",
+    "font-medium text-xs leading-none",
     "bg-(--mention-bg) text-(--mention-text)",
     '[&_[data-component-part="icon-svg"]]:bg-(--mention-text)',
     '[&_[data-component-part="icon-svg"]]:size-3',

--- a/packages/components/src/components/mention/mention.tsx
+++ b/packages/components/src/components/mention/mention.tsx
@@ -130,8 +130,8 @@ const Mention = ({
 
   const sharedClassName = cn(
     "mention",
-    "inline-flex items-center gap-1 rounded-md px-2 py-1",
-    "font-medium text-xs leading-none",
+    "inline-flex items-center gap-1 rounded-md px-1.5 py-0.5",
+    "font-medium text-xs",
     "bg-(--mention-bg) text-(--mention-text)",
     '[&_[data-component-part="icon-svg"]]:bg-(--mention-text)',
     '[&_[data-component-part="icon-svg"]]:size-3',

--- a/packages/components/src/components/mention/mention.tsx
+++ b/packages/components/src/components/mention/mention.tsx
@@ -80,7 +80,8 @@ const Mention = ({
 }: MentionProps) => {
   const isUser = !!user;
   const defaultIconName = isUser ? DEFAULT_USER_ICON : DEFAULT_PAGE_ICON;
-  const resolvedIcon = icon ?? defaultIconName;
+  // Treat an empty string the same as omitted — fall back to the default icon.
+  const resolvedIcon = (icon === "" ? undefined : icon) ?? defaultIconName;
 
   const renderIcon = () => {
     if (typeof resolvedIcon !== "string") {

--- a/packages/components/src/components/mention/mention.tsx
+++ b/packages/components/src/components/mention/mention.tsx
@@ -104,7 +104,7 @@ const Mention = ({
         <img
           alt=""
           aria-hidden="true"
-          className="size-3 shrink-0 rounded-full object-cover"
+          className="size-[1em] shrink-0 rounded-full object-cover"
           height={12}
           src={resolvedIcon}
           width={12}
@@ -141,15 +141,21 @@ const Mention = ({
   // When there is no icon both sides use the wider right padding value.
   const sharedClassName = cn(
     "mention",
-    "inline-flex items-center gap-1 rounded-md py-0.5",
-    // Icon present: tight left padding so the icon is equally inset on all
-    // three sides (matches the 4px vertical gap). Right side stays wider.
-    // No icon: symmetric padding matching the right-side value.
-    resolvedIcon !== null ? "pr-2 pl-1" : "px-2",
-    "font-medium text-xs",
+    // leading-none keeps line-height = 1em so all em-based dimensions
+    // scale proportionally with any font-size applied by the consumer.
+    "inline-flex items-center leading-none",
+    // Spacing and radius all in em so every dimension scales with font-size.
+    // py = 1/3em  →  pill height = 1em (text) + 2*(1/3em) = 5/3em ≈ 1.667×
+    // pl = 1/3em  →  icon is equidistant from left, top, and bottom edges
+    // pr = 2/3em  →  right side has double the icon-gap for label breathing room
+    // no-icon: symmetric at 2/3em on both sides
+    "gap-[0.333em] rounded-[0.5em] py-[0.333em]",
+    resolvedIcon !== null ? "pr-[0.667em] pl-[0.333em]" : "px-[0.667em]",
+    "font-medium",
     "bg-(--mention-bg) text-(--mention-text)",
     '[&_[data-component-part="icon-svg"]]:bg-(--mention-text)',
-    '[&_[data-component-part="icon-svg"]]:size-3',
+    // Icon sized to 1em so it always matches the current font-size exactly.
+    '[&_[data-component-part="icon-svg"]]:size-[1em]',
     colorVariants[color],
     isLink && "cursor-pointer no-underline transition-opacity hover:opacity-80",
     className

--- a/packages/components/src/constants/selectors.ts
+++ b/packages/components/src/constants/selectors.ts
@@ -11,6 +11,7 @@ const _classes = {
   Field: "field",
   Frame: "frame",
   Icon: "icon",
+  Mention: "mention",
   Mermaid: "mermaid",
   Step: "step",
   Steps: "steps",


### PR DESCRIPTION
## Summary

- Introduces a new `Mention` component to `@mintlify/components` for rendering inline page and user references as small icon + label pills

  <table border="1">
    <tr>
      <td><img width="559" height="auto" alt="Google Chrome 2026-08-13 22 20 21" src="https://github.com/user-attachments/assets/475c372f-1e73-47cf-a8de-242487e48815" /></td>
    </tr><tr></tr>
    <tr>
      <td><img width="493" height="auto" alt="CleanShot 2026-08-13 at 22 19 41@2x" src="https://github.com/user-attachments/assets/c03591d5-959e-4c37-8c46-7cb2e1897c7c" /></td>
    </tr><tr></tr>
    <tr>
      <td><img width="493" height="auto" alt="Google Chrome 2026-08-13 22 19 39" src="https://github.com/user-attachments/assets/8018ea88-31d0-4dba-bf77-0c03612466e3" /></td>
    </tr>
  </table>


## Component API

Single `Mention` component with minimal props. Specify either `path` (page mention) or `user` (user mention):

```mdx
{/* Page mention — renders as a link */}
<Mention path="/travel" icon="plane" color="info">Travel</Mention>
<Mention path="/accommodation" icon="bed" color="info">Accommodation & Meals</Mention>

{/* User mention */}
<Mention user="james-baduor" color="info">James Baduor</Mention>

{/* User mention with avatar URL */}
<Mention user="james-baduor" icon="https://example.com/avatar.jpg">James Baduor</Mention>
```

**Props:** `path`, `user`, `icon` (FA/Lucide name, URL, or ReactNode), `iconType`, `iconLibrary`, `color`, `className`

**Color variants:** `neutral` (default) · `info` · `success` · `warning` · `feature` · `error`

## Implementation notes

- Zero runtime JS — pure CSS/Tailwind, no client-side logic
- Full dark mode support via CSS custom properties (`--mention-bg`, `--mention-text`)
- Inline `inline-flex` element designed to sit naturally inside prose content
- `icon` prop handles FA/Lucide names, image URLs (circular avatar), and React nodes
- Storybook stories cover all color variants, page/user types, inline prose context, and the design reference layout

## Test plan

- [x] Run `pnpm storybook` in `packages/components` and verify all stories render correctly
- [x] Confirm page mentions render as `<a>` tags, user mentions as `<span>`
- [x] Test icon URL renders as circular avatar image
- [x] Test custom icon name (e.g. `plane`, `bed`) renders correctly
- [x] Verify dark mode colors look correct
- [x] Check inline prose story matches the Paper design reference

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New presentational UI in the components package with no changes to auth, data, or existing component behavior.
> 
> **Overview**
> Adds a new **`Mention`** component to `@mintlify/components` for inline page and user references as icon + label pills (Paper / Notion-style @mentions).
> 
> **`path`** renders an `<a>` with a default file icon; **`user`** renders a `<span>` with a default person icon. **`icon`** accepts FontAwesome/Lucide names, image URLs (circular avatars), React nodes, or can be hidden with `null`. Six **`color`** variants use CSS variables with dark mode; layout uses **`em`** units so pills scale with surrounding font size.
> 
> The package barrel export and **`Classes.Mention`** selector are updated. Storybook stories cover colors, sizes, Lucide, avatars, prose/checklist context, and long-label wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 965147d389b2cbb7bde69473a8e50e7b03881d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->