### PR TITLE
fix(steps): anchor the empty-step-content :has to the step item

### DIFF
--- a/packages/components/biome.jsonc
+++ b/packages/components/biome.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "extends": ["ultracite/biome/core", "ultracite/biome/react"],
+  "plugins": ["./plugins/no-universal-has.grit"],
   "css": {
     "parser": {
       "tailwindDirectives": true

--- a/packages/components/biome.jsonc
+++ b/packages/components/biome.jsonc
@@ -1,7 +1,10 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "extends": ["ultracite/biome/core", "ultracite/biome/react"],
-  "plugins": ["./plugins/no-universal-has.grit"],
+  "plugins": [
+    "./plugins/no-universal-has.grit",
+    "./plugins/no-universal-has-css.grit"
+  ],
   "css": {
     "parser": {
       "tailwindDirectives": true

--- a/packages/components/plugins/no-universal-has-css.grit
+++ b/packages/components/plugins/no-universal-has-css.grit
@@ -1,0 +1,6 @@
+language css
+
+`$sel { $decls }` where {
+  $sel <: r"(?s)(?:.*,)?\s*:has\(.*",
+  register_diagnostic(span=$sel, message="universal-subject :has selector is banned; anchor :has to a specific element")
+}

--- a/packages/components/plugins/no-universal-has.grit
+++ b/packages/components/plugins/no-universal-has.grit
@@ -1,0 +1,11 @@
+language js
+
+// group-has-* compiles to a :has() selector with a universal subject, which
+// forces whole-document style recalc on every dom mutation in consumers.
+// anchor the variant to a stable ancestor instead, e.g.
+// [[role=listitem]:has([data-component-part=step-content]:empty)_&]:hidden
+`$s` where {
+  $s <: string(),
+  $s <: includes "group-has-",
+  register_diagnostic(span=$s, message="universal-subject :has variant (group-has-*) is banned; anchor :has to a stable ancestor")
+}

--- a/packages/components/src/code.css
+++ b/packages/components/src/code.css
@@ -83,17 +83,14 @@ html.dark [data-fade-overlay] {
   );
 }
 
-:has([data-floating-buttons])
+[data-has-floating-buttons]
   > [data-component-part="code-block-root"]
   pre
   > code {
   padding-right: var(--code-padding-right, 0px) !important;
 }
 
-:has([data-component-part="code-block-header"])
-  > [data-component-part="code-block-root"]
-  pre
-  > code {
+[data-has-header] > [data-component-part="code-block-root"] pre > code {
   padding-right: var(--code-padding-right, 48px) !important;
 }
 

--- a/packages/components/src/components/code-block/code-block.tsx
+++ b/packages/components/src/components/code-block/code-block.tsx
@@ -117,6 +117,9 @@ const CodeBlock = function CodeBlock(params: CodeBlockProps) {
         className
       )}
       ref={anchorRef}
+      {...(hasGrayBackgroundContainer
+        ? { "data-has-header": "" }
+        : { "data-has-floating-buttons": "" })}
     >
       {hasGrayBackgroundContainer ? (
         <CodeHeader

--- a/packages/components/src/components/steps/steps.tsx
+++ b/packages/components/src/components/steps/steps.tsx
@@ -150,7 +150,7 @@ const StepsItem = ({
         className={cn(
           "absolute top-11 h-[calc(100%-2.75rem)] w-px",
           isLast
-            ? 'bg-linear-to-b from-stone-200 via-80% via-stone-200 to-transparent group-has-[[data-component-part="step-content"]:empty]/step:hidden dark:from-white/10 dark:via-white/10'
+            ? "bg-linear-to-b from-stone-200 via-80% via-stone-200 to-transparent dark:from-white/10 dark:via-white/10 [[role=listitem]:has([data-component-part=step-content]:empty)_&]:hidden"
             : "bg-stone-200/70 dark:bg-white/10"
         )}
         contentEditable={false}

--- a/packages/components/src/components/steps/steps.tsx
+++ b/packages/components/src/components/steps/steps.tsx
@@ -150,7 +150,7 @@ const StepsItem = ({
         className={cn(
           "absolute top-11 h-[calc(100%-2.75rem)] w-px",
           isLast
-            ? "bg-linear-to-b from-stone-200 via-80% via-stone-200 to-transparent dark:from-white/10 dark:via-white/10 [[role=listitem]:has([data-component-part=step-content]:empty)_&]:hidden"
+            ? "bg-linear-to-b from-stone-200 via-80% via-stone-200 to-transparent dark:from-white/10 dark:via-white/10 [[data-component-part=step-item]:has([data-component-part=step-content]:empty)_&]:hidden"
             : "bg-stone-200/70 dark:bg-white/10"
         )}
         contentEditable={false}


### PR DESCRIPTION
## Summary
Removes both sources of universal-subject `:has()` selectors, which force whole-document style recalc on every DOM mutation in consumers:

- **Steps**: `group-has-[...]/step:hidden` re-anchored to the step item: `[[role=listitem]:has(…)_&]:hidden`.
- **code.css**: the two bare `:has(…) > [data-component-part=code-block-root]` padding rules could only ever match the CodeBlock root div, which already knows at render time whether it has a header or floating buttons — the root now stamps `data-has-header` / `data-has-floating-buttons` and the rules anchor to those. CodeGroup never matched either rule.

Biome GritQL plugins ban both shapes from returning: `group-has-` in JS/TSX strings, bare `:has(` selectors in css (anchored `:has` stays allowed).

Consumer impact: perf-only; the DOM gains one inert `data-has-*` attribute on the CodeBlock root (snapshot-test churn at bump time).

## Test Plan
- `pnpm build`: no `group-has` or universal-subject `:has(` anywhere in dist
- `pnpm lint:check` green; both plugins fire on synthetic violations, silent on anchored `:has`
- rendered behavior unchanged: connector hidden on empty step content; code padding identical across header/floating-button/group variants

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-oriented selector and attribute changes with no intended behavior change; only an extra inert `data-has-*` on CodeBlock roots for consumers.
> 
> **Overview**
> Eliminates **universal-subject `:has()`** patterns that trigger expensive whole-document style recalc on DOM mutations in consuming apps.
> 
> **Steps:** The last-step connector hide rule drops `group-has-…/step` in favor of an ancestor-anchored variant: `[[data-component-part=step-item]:has([data-component-part=step-content]:empty)_&]:hidden` (same UX: line hidden when step content is empty).
> 
> **Code blocks:** `code.css` no longer uses bare `:has(…)` for padding; the **CodeBlock** root now sets `data-has-header` or `data-has-floating-buttons` at render time, and CSS targets those attributes instead.
> 
> **Lint:** Two Biome Grit plugins block regressions—`group-has-` in class strings and universal-subject `:has(` in CSS (anchored `:has` remains allowed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d81bb02a480efdddb888e6d922e24cd1b8013d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->