### PR TITLE
1.0.19 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.19] - 2026-08-20
+
+### Fixed
+
+- Anchored the universal-subject `:has()` selectors in Steps and code.css to their owning elements, eliminating whole-document style invalidation in consumers (#255)
+
 ## [1.0.18] - 2026-07-01
 
 ### Added

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mintlify/components",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Mintlify open-source UI components",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
update changelog and bump version for the #255 :has anchoring fixes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release; the behavioral CSS fix is already merged via #255 and this PR does not change runtime code.
> 
> **Overview**
> **Release 1.0.19** for `@mintlify/components`: bumps the package version from `1.0.18` to `1.0.19` and documents the shipped fix in `CHANGELOG.md`.
> 
> The changelog entry for this release describes anchoring universal-subject `:has()` selectors in **Steps** and **`code.css`** to their owning elements (#255), which avoids whole-document style invalidation when consumers use the library styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4219910e13cfdf00f82ee0d077d78c32acef17db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->